### PR TITLE
엔티티 컬럼명 수정 및 스크랩 도메인 조회 쿼리 수정

### DIFF
--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/impl/AuthServiceImpl.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/impl/AuthServiceImpl.java
@@ -52,7 +52,7 @@ public class AuthServiceImpl implements AuthService {
     public LoginResponseDto login(AuthLoginRequestDto authLoginRequestDto) {
 
         User user = checkEmailExist(authLoginRequestDto);
-        checkPassword(authLoginRequestDto.getPassword(), user);
+        checkPassword(authLoginRequestDto.getPassword(), user.getPassword());
         user.setFcmToken(authLoginRequestDto.getFcmToken());
         return LoginResponseDto.of(user, jwtTokenProvider.createToken(user.getUserSeq(), user.getRoleType()));
     }
@@ -98,9 +98,9 @@ public class AuthServiceImpl implements AuthService {
                 });
     }
 
-    private void checkPassword(String password, User user) {
+    private void checkPassword(String password, String originPassword) {
 
-        if (!passwordEncoder.matches(password, user.getPassword())) {
+        if (!passwordEncoder.matches(password, originPassword)) {
             throw new GlobalBadRequestException(ErrorCode.INVALID_PASSWORD);
         }
     }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/ErrorResponse.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/ErrorResponse.java
@@ -5,8 +5,8 @@ import lombok.Data;
 
 @AllArgsConstructor
 @Data
-public class GlobalExceptionResponse {
+public class ErrorResponse {
 
-	private String code;
-	private String message;
+    private String code;
+    private String message;
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/GlobalExceptionHandler.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/GlobalExceptionHandler.java
@@ -18,11 +18,10 @@ import java.net.BindException;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    //
     @ExceptionHandler(GlobalBadRequestException.class)
-    public ResponseEntity<GlobalExceptionResponse> badRequestException(GlobalBadRequestException e) {
-        return ResponseEntity.badRequest()
-                .body(new GlobalExceptionResponse(e.getErrorCode().getCode(),
-                        e.getErrorCode().getMessage()));
+    public ResponseEntity<ErrorResponse> badRequestException(GlobalBadRequestException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getErrorCode().getCode(), e.getErrorCode().getMessage()));
     }
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -33,17 +32,16 @@ public class GlobalExceptionHandler {
             HttpRequestMethodNotSupportedException.class,
             MethodArgumentTypeMismatchException.class
     })
-    public ResponseEntity<GlobalExceptionResponse> badRequest(Exception e) {
+    public ResponseEntity<ErrorResponse> badRequest(Exception e) {
 
-        return ResponseEntity.badRequest()
-                .body(new GlobalExceptionResponse(ErrorCode.BAD_REQUEST.getCode(), e.getMessage()));
+        return ResponseEntity.badRequest().body(new ErrorResponse(ErrorCode.BAD_REQUEST.getCode(), e.getMessage()));
     }
 
     @ExceptionHandler(NoHandlerFoundException.class)
-    public ResponseEntity<GlobalExceptionResponse> handleError404() {
+    public ResponseEntity<ErrorResponse> handleError404() {
         String code = ErrorCode.NOT_FOUND_API.getCode();
         String message = ErrorCode.NOT_FOUND_API.getCode();
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new GlobalExceptionResponse(code, message));
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(new ErrorResponse(code, message));
     }
 
     @ExceptionHandler(org.springframework.validation.BindException.class)

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/group/presentation/dto/GroupAssembler.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/group/presentation/dto/GroupAssembler.java
@@ -17,6 +17,7 @@ public abstract class GroupAssembler {
                 userGroup.getGroupIcon(),
                 userGroup.getGroupName(),
                 userGroup.getGroupType(),
+                null,
                 userGroup.getInviteLink()
         );
     }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/MemoryController.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/MemoryController.java
@@ -11,7 +11,7 @@ import cmc.mellyserver.mellyapi.memory.presentation.dto.request.MemoryUpdateRequ
 import cmc.mellyserver.mellyapi.memory.presentation.dto.response.MemoryResponse;
 import cmc.mellyserver.mellycommon.enums.GroupType;
 import cmc.mellyserver.mellycore.group.application.GroupService;
-import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupListForSaveMemoryResponseDto;
+import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupLoginUserParticipatedResponseDto;
 import cmc.mellyserver.mellycore.memory.application.MemoryService;
 import cmc.mellyserver.mellycore.memory.application.dto.response.MemoryUpdateFormResponseDto;
 import cmc.mellyserver.mellycore.memory.domain.repository.dto.MemoryResponseDto;
@@ -41,7 +41,7 @@ public class MemoryController {
     @GetMapping("/group")
     public ResponseEntity<ApiResponse> getGroupListForSaveMemory(@AuthenticationPrincipal User user) {
 
-        List<GroupListForSaveMemoryResponseDto> userGroup = groupService.findGroupListLoginUserParticipateForMemoryCreate(Long.parseLong(user.getUsername()));
+        List<GroupLoginUserParticipatedResponseDto> userGroup = groupService.findGroupListLoginUserParticipateForMemoryCreate(Long.parseLong(user.getUsername()));
         return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS, MemoryAssembler.groupListForSaveMemoryResponse(userGroup)));
     }
 
@@ -106,7 +106,7 @@ public class MemoryController {
     public ResponseEntity<ApiResponse> findMemory(@AuthenticationPrincipal User user, @PathVariable Long memoryId) {
 
         MemoryResponseDto memoryByMemoryId = memoryService.findMemoryByMemoryId(Long.parseLong(user.getUsername()), memoryId);
-        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS, MemoryAssembler.memoryResponse(memoryByMemoryId)));
+        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS, MemoryResponse.of(memoryByMemoryId)));
     }
 
 

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/common/MemoryAssembler.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/common/MemoryAssembler.java
@@ -6,7 +6,7 @@ import cmc.mellyserver.mellyapi.memory.presentation.dto.response.FindPlaceInfoBy
 import cmc.mellyserver.mellyapi.memory.presentation.dto.response.GroupListForSaveMemoryResponse;
 import cmc.mellyserver.mellyapi.memory.presentation.dto.response.MemoryResponse;
 import cmc.mellyserver.mellyapi.memory.presentation.dto.response.MemoryUpdateFormResponse;
-import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupListForSaveMemoryResponseDto;
+import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupLoginUserParticipatedResponseDto;
 import cmc.mellyserver.mellycore.memory.application.dto.request.CreateMemoryRequestDto;
 import cmc.mellyserver.mellycore.memory.application.dto.request.UpdateMemoryRequestDto;
 import cmc.mellyserver.mellycore.memory.application.dto.response.MemoryUpdateFormResponseDto;
@@ -20,32 +20,14 @@ import java.util.stream.Collectors;
 
 public class MemoryAssembler {
 
-    public static List<GroupListForSaveMemoryResponse> groupListForSaveMemoryResponse(
-            List<GroupListForSaveMemoryResponseDto> groupListForSaveMemoryResponseDtoList) {
-        return groupListForSaveMemoryResponseDtoList.stream()
-                .map(each ->
-                        GroupListForSaveMemoryResponse.builder().groupId(each.getGroupId())
-                                .groupName(each.getGroupName())
-                                .groupType(each.getGroupType()).build())
+    public static List<GroupListForSaveMemoryResponse> groupListForSaveMemoryResponse(List<GroupLoginUserParticipatedResponseDto> groupLoginUserParticipatedResponseDtos) {
+        return groupLoginUserParticipatedResponseDtos.stream()
+                .map(GroupListForSaveMemoryResponse::of)
                 .collect(Collectors.toList());
     }
 
-    public static Slice<MemoryResponse> memoryResponses(
-            Slice<MemoryResponseDto> memoryResponseDtos) {
-        return memoryResponseDtos.map(each -> MemoryResponse.builder()
-                .placeId(each.getPlaceId())
-                .placeName(each.getPlaceName())
-                .memoryId(each.getMemoryId())
-                .imageDtos(each.getMemoryImages())
-                .title(each.getTitle())
-                .content(each.getContent())
-                .groupType(each.getGroupType())
-                .groupName(each.getGroupName())
-                .stars(each.getStars())
-                .keyword(each.getKeyword())
-                .loginUserWrite(each.isLoginUserWrite())
-                .visitedDate(each.getVisitedDate())
-                .build());
+    public static Slice<MemoryResponse> memoryResponses(Slice<MemoryResponseDto> memoryResponseDtos) {
+        return memoryResponseDtos.map(MemoryResponse::of);
     }
 
     public static MemoryResponse memoryResponse(MemoryResponseDto memoryResponseDto) {

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/response/GroupListForSaveMemoryResponse.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/response/GroupListForSaveMemoryResponse.java
@@ -1,19 +1,25 @@
 package cmc.mellyserver.mellyapi.memory.presentation.dto.response;
 
 import cmc.mellyserver.mellycommon.enums.GroupType;
+import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupLoginUserParticipatedResponseDto;
 import lombok.Builder;
 import lombok.Data;
 
 @Data
 public class GroupListForSaveMemoryResponse {
-	private Long groupId;
-	private String groupName;
-	private GroupType groupType;
+    private Long groupId;
+    private String groupName;
+    private GroupType groupType;
 
-	@Builder
-	public GroupListForSaveMemoryResponse(Long groupId, String groupName, GroupType groupType) {
-		this.groupId = groupId;
-		this.groupName = groupName;
-		this.groupType = groupType;
-	}
+    @Builder
+    public GroupListForSaveMemoryResponse(Long groupId, String groupName, GroupType groupType) {
+        this.groupId = groupId;
+        this.groupName = groupName;
+        this.groupType = groupType;
+    }
+
+    public static GroupListForSaveMemoryResponse of(GroupLoginUserParticipatedResponseDto groupLoginUserParticipatedResponseDto) {
+        return GroupListForSaveMemoryResponse.builder().groupId(groupLoginUserParticipatedResponseDto.getGroupId()).groupName(groupLoginUserParticipatedResponseDto.getGroupName())
+                .groupType(groupLoginUserParticipatedResponseDto.getGroupType()).build();
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/response/MemoryResponse.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/memory/presentation/dto/response/MemoryResponse.java
@@ -1,47 +1,64 @@
 package cmc.mellyserver.mellyapi.memory.presentation.dto.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import com.fasterxml.jackson.annotation.JsonFormat;
-
 import cmc.mellyserver.mellycommon.enums.GroupType;
 import cmc.mellyserver.mellycore.memory.domain.repository.dto.ImageDto;
+import cmc.mellyserver.mellycore.memory.domain.repository.dto.MemoryResponseDto;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Data
 public class MemoryResponse {
 
-	private Long placeId;
-	private String placeName;
-	private Long memoryId;
-	private List<ImageDto> memoryImages;
-	private String title;
-	private String content;
-	private GroupType groupType;
-	private String groupName;
-	private Long stars;
-	private List<String> keyword;
-	private boolean loginUserWrite;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmm")
-	private LocalDateTime visitedDate;
+    private Long placeId;
+    private String placeName;
+    private Long memoryId;
+    private List<ImageDto> memoryImages;
+    private String title;
+    private String content;
+    private GroupType groupType;
+    private String groupName;
+    private Long stars;
+    private List<String> keyword;
+    private boolean loginUserWrite;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyyMMddHHmm")
+    private LocalDateTime visitedDate;
 
-	@Builder
-	public MemoryResponse(Long placeId, String placeName, Long memoryId, List<ImageDto> imageDtos, String title,
-		String content, GroupType groupType, String groupName, Long stars, List<String> keyword, boolean loginUserWrite,
-		LocalDateTime visitedDate) {
-		this.placeId = placeId;
-		this.placeName = placeName;
-		this.memoryId = memoryId;
-		this.memoryImages = imageDtos;
-		this.title = title;
-		this.content = content;
-		this.groupType = groupType;
-		this.groupName = groupName;
-		this.stars = stars;
-		this.keyword = keyword;
-		this.loginUserWrite = loginUserWrite;
-		this.visitedDate = visitedDate;
-	}
+    @Builder
+    public MemoryResponse(Long placeId, String placeName, Long memoryId, List<ImageDto> imageDtos, String title,
+                          String content, GroupType groupType, String groupName, Long stars, List<String> keyword, boolean loginUserWrite,
+                          LocalDateTime visitedDate) {
+        this.placeId = placeId;
+        this.placeName = placeName;
+        this.memoryId = memoryId;
+        this.memoryImages = imageDtos;
+        this.title = title;
+        this.content = content;
+        this.groupType = groupType;
+        this.groupName = groupName;
+        this.stars = stars;
+        this.keyword = keyword;
+        this.loginUserWrite = loginUserWrite;
+        this.visitedDate = visitedDate;
+    }
+
+    public static MemoryResponse of(MemoryResponseDto memoryResponseDto) {
+        return MemoryResponse.builder()
+                .placeId(memoryResponseDto.getPlaceId())
+                .placeName(memoryResponseDto.getPlaceName())
+                .memoryId(memoryResponseDto.getMemoryId())
+                .imageDtos(memoryResponseDto.getMemoryImages())
+                .title(memoryResponseDto.getTitle())
+                .content(memoryResponseDto.getContent())
+                .groupType(memoryResponseDto.getGroupType())
+                .groupName(memoryResponseDto.getGroupName())
+                .stars(memoryResponseDto.getStars())
+                .keyword(memoryResponseDto.getKeyword())
+                .loginUserWrite(memoryResponseDto.isLoginUserWrite())
+                .visitedDate(memoryResponseDto.getVisitedDate())
+                .build();
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/UserController.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/UserController.java
@@ -92,7 +92,7 @@ public class UserController {
     }
 
     @GetMapping("/group")
-    public ResponseEntity<ApiResponse> getUserGroup(@AuthenticationPrincipal User user) throws InterruptedException {
+    public ResponseEntity<ApiResponse> getUserGroup(@AuthenticationPrincipal User user) {
 
         List<GroupLoginUserParticipatedResponseDto> results = groupService.findGroupListLoginUserParticiated(Long.parseLong(user.getUsername()));
         return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS, UserAssembler.groupLoginUserParticipatedResponses(results)));

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/UserAssembler.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/UserAssembler.java
@@ -28,8 +28,6 @@ public abstract class UserAssembler {
                         .groupType(response.getGroupType())
                         .groupName(response.getGroupName())
                         .groupIcon(response.getGroupIcon())
-                        .users(response.getUsers())
-                        .invitationLink(response.getInvitationLink())
                         .build()
         ).collect(Collectors.toList());
     }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/UserAssembler.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/UserAssembler.java
@@ -28,6 +28,7 @@ public abstract class UserAssembler {
                         .groupType(response.getGroupType())
                         .groupName(response.getGroupName())
                         .groupIcon(response.getGroupIcon())
+                        .users(response.getUsers())
                         .invitationLink(response.getInvitationLink())
                         .build()
         ).collect(Collectors.toList());

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/response/GroupLoginUserParticipatedResponse.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/user/presentation/dto/response/GroupLoginUserParticipatedResponse.java
@@ -2,10 +2,11 @@ package cmc.mellyserver.mellyapi.user.presentation.dto.response;
 
 import cmc.mellyserver.mellycommon.enums.GroupType;
 import cmc.mellyserver.mellycore.user.domain.repository.UserDto;
-import java.util.List;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -20,10 +21,11 @@ public class GroupLoginUserParticipatedResponse {
 
     @Builder
     public GroupLoginUserParticipatedResponse(Long groupId, int groupIcon, String groupName,
-            GroupType groupType,
-            String invitationLink) {
+                                              GroupType groupType, List<UserDto> users,
+                                              String invitationLink) {
         this.groupId = groupId;
         this.groupIcon = groupIcon;
+        this.users = users;
         this.groupName = groupName;
         this.groupType = groupType;
         this.invitationLink = invitationLink;

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/common/util/jpa/QueryDslUtil.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/common/util/jpa/QueryDslUtil.java
@@ -8,8 +8,8 @@ import com.querydsl.core.types.dsl.Expressions;
 public class QueryDslUtil {
 
 	public static OrderSpecifier<?> getSortedColumn(Order order, Path<?> parent, String fieldName) {
-		Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
 
+		Path<Object> fieldPath = Expressions.path(Object.class, parent, fieldName);
 		return new OrderSpecifier(order, fieldPath);
 	}
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/DataSourceConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/DataSourceConfig.java
@@ -17,9 +17,8 @@ import static cmc.mellyserver.mellycore.config.datasource.DataSourceKey.KeyName.
 @Configuration
 public class DataSourceConfig {
 
-
     @Bean
-    @Qualifier(SOURCE_SERVER) // 같은 타입의 빈이라도 이름 지정 가능하다
+    @Qualifier(SOURCE_SERVER)
     @ConfigurationProperties(prefix = "spring.datasource.source")
     public DataSource sourceDataSource() {
         return DataSourceBuilder.create()
@@ -33,35 +32,19 @@ public class DataSourceConfig {
         return DataSourceBuilder.create()
                 .build();
     }
-//
-//    @Bean
-//    @Qualifier(REPLICA_SERVER_2)
-//    @ConfigurationProperties(prefix = "spring.datasource.replica2")
-//    public DataSource replica2DataSource() {
-//        return DataSourceBuilder.create().type(HikariDataSource.class)
-//                .build();
-//    }
 
     @Bean
-    public DataSource routingDataSource(
-            @Qualifier(SOURCE_SERVER) DataSource sourceDataSource,
-            @Qualifier(REPLICA_SERVER_1) DataSource replica1DataSource
-//            @Qualifier(REPLICA_SERVER_2) DataSource replica2DataSource
-    ) {
+    public DataSource routingDataSource(@Qualifier(SOURCE_SERVER) DataSource sourceDataSource, @Qualifier(REPLICA_SERVER_1) DataSource replica1DataSource) {
+
         RoutingDataSource routingDataSource = new RoutingDataSource();
 
-        // dataSource 리스트를 맵으로 routingDataSource에 넘겨준다.
         HashMap<Object, Object> dataSourceMap = new HashMap<>();
         dataSourceMap.put(SOURCE_SERVER, sourceDataSource);
         dataSourceMap.put(REPLICA_SERVER_1, replica1DataSource);
-//        dataSourceMap.put(REPLICA_SERVER_2, replica2DataSource);
 
-        // 목표로 하는 데이터 소스 맵을 넘겨준다.
         routingDataSource.setTargetDataSources(dataSourceMap);
-        // 기본이 되는 데이터 소스를 지정한다.
         routingDataSource.setDefaultTargetDataSource(sourceDataSource);
         routingDataSource.afterPropertiesSet();
-
 
         return routingDataSource;
     }
@@ -71,6 +54,4 @@ public class DataSourceConfig {
     public DataSource dataSource(@Qualifier("routingDataSource") DataSource routingDataSource) {
         return new LazyConnectionDataSourceProxy(routingDataSource);
     }
-
-
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/DataSourceKey.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/DataSourceKey.java
@@ -7,7 +7,7 @@ import java.util.stream.Collectors;
 public enum DataSourceKey {
     SOURCE(KeyName.SOURCE_SERVER, false),
     REPLICA_1(KeyName.REPLICA_SERVER_1, true);
-//    REPLICA_2(KeyName.REPLICA_SERVER_2, true);
+
 
     private final String key;
     private final boolean isReplica;
@@ -23,11 +23,9 @@ public enum DataSourceKey {
                 .collect(Collectors.toList());
     }
 
-    // 어노테이션에서도 참조할 수 있도록 중첩 클래스에 상수 선언
+
     public static class KeyName {
         public static final String SOURCE_SERVER = "SOURCE";
         public static final String REPLICA_SERVER_1 = "REPLICA_1";
-//        public static final String REPLICA_SERVER_2 = "REPLICA_2";
-
     }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RandomReplicaKeys.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RandomReplicaKeys.java
@@ -8,6 +8,7 @@ public class RandomReplicaKeys {
     private static final ThreadLocalRandom random = ThreadLocalRandom.current();
 
     private final List<DataSourceKey> dataSourceKeys;
+
     private final int size;
 
     public RandomReplicaKeys() {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RoutingDataSource.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RoutingDataSource.java
@@ -13,10 +13,9 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
 
     @Override
     protected Object determineCurrentLookupKey() {
-        log.info("호출");
-        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
 
-        System.out.println("Transaction의 Read Only가 " + isReadOnly + " 입니다.");
+        boolean isReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+        log.info("Transaction Read Only : {}", isReadOnly);
 
         if (isReadOnly) {
 //            return randomReplicaKeys.next();

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RoutingDataSource.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/datasource/RoutingDataSource.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-import static cmc.mellyserver.mellycore.config.datasource.DataSourceKey.KeyName.REPLICA_SERVER_1;
 import static cmc.mellyserver.mellycore.config.datasource.DataSourceKey.KeyName.SOURCE_SERVER;
 
 @Slf4j
@@ -21,7 +20,7 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
 
         if (isReadOnly) {
 //            return randomReplicaKeys.next();
-            return REPLICA_SERVER_1;
+            return SOURCE_SERVER;
         }
 
         return SOURCE_SERVER;

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/jpa/QuerydslConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/jpa/QuerydslConfig.java
@@ -8,11 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
 
-/**
- * QuerydslConfig.java
- *
- * @author jemlog
- */
 @Configuration
 public class QuerydslConfig {
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/CacheConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/CacheConfig.java
@@ -21,42 +21,28 @@ import java.time.Duration;
 @Configuration
 public class CacheConfig {
 
-
     @Autowired
     RedisConnectionFactory redisConnectionFactory;
 
-
     public ObjectMapper objectMapper() {
 
-        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator
-                .builder().allowIfSubType(Object.class)
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType(Object.class)
                 .build();
 
-        return new ObjectMapper()
-                .findAndRegisterModules()
-                .activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL,
-                        JsonTypeInfo.As.PROPERTY)
+        return new ObjectMapper().findAndRegisterModules()
+                .activateDefaultTyping(typeValidator, ObjectMapper.DefaultTyping.NON_FINAL, JsonTypeInfo.As.PROPERTY)
                 .registerModules(new JavaTimeModule());
-
-
     }
 
     @Bean
     public CacheManager redisCacheManager() {
 
         RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-                        new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper())))
                 .entryTtl(Duration.ofMinutes(20));
 
         return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
     }
-
-//    @Bean
-//    public CacheManager cacheManager() {
-//        return new ConcurrentMapCacheManager();
-//    }
-
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/CacheConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/CacheConfig.java
@@ -5,13 +5,25 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class CacheConfig {
 
-//    @Autowired
-//    RedisConnectionFactory redisConnectionFactory;
+
+    @Autowired
+    RedisConnectionFactory redisConnectionFactory;
 
 
     public ObjectMapper objectMapper() {
@@ -29,19 +41,18 @@ public class CacheConfig {
 
     }
 
-//
-//    @Bean
-//    public CacheManager redisCacheManager() {
-//
-//        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-//                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
-//                        new StringRedisSerializer()))
-//                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
-//                        new GenericJackson2JsonRedisSerializer(objectMapper())))
-//                .entryTtl(Duration.ofSeconds(20));
-//
-//        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
-//    }
+    @Bean
+    public CacheManager redisCacheManager() {
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new GenericJackson2JsonRedisSerializer(objectMapper())))
+                .entryTtl(Duration.ofMinutes(20));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    }
 
 //    @Bean
 //    public CacheManager cacheManager() {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/RedisConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/RedisConfig.java
@@ -1,32 +1,38 @@
 package cmc.mellyserver.mellycore.config.redis;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
-
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @Profile("local")
 public class RedisConfig {
 
-//    @Value("${spring.redis.host}")
-//    private String host;
-//
-//    @Value("${spring.redis.port}")
-//    private int port;
-//
-//    @Bean
-//    public RedisConnectionFactory redisConnectionFactory() {
-//
-//        return new LettuceConnectionFactory(host, port);
-//    }
-//
-//    @Bean
-//    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
-//        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-//        redisTemplate.setConnectionFactory(redisConnectionFactory);
-//        redisTemplate.setKeySerializer(new StringRedisSerializer());
-//        redisTemplate.setValueSerializer(new StringRedisSerializer());
-//        return redisTemplate;
-//    }
+    @Value("${spring.redis.host}")
+    private String host;
 
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/application/GroupService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/application/GroupService.java
@@ -18,6 +18,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -40,18 +41,18 @@ public class GroupService {
         });
     }
 
-    //    @Cacheable(value = "groupList", key = "#userSeq", cacheManager = "redisCacheManager")
+
+    @Cacheable(value = "groupList", key = "#userSeq", cacheManager = "redisCacheManager")
     @Transactional(readOnly = true)
-    public List<GroupLoginUserParticipatedResponseDto> findGroupListLoginUserParticiated(Long userSeq) throws InterruptedException {
-        Thread.sleep(3000);
+    public List<GroupLoginUserParticipatedResponseDto> findGroupListLoginUserParticiated(Long userSeq) {
         return userGroupQueryRepository.getGroupListLoginUserParticipate(userSeq);
     }
 
-    @Cacheable(value = "findGroups", key = "#userSeq")
+    @Cacheable(value = "findGroups", key = "#userSeq", cacheManager = "redisCacheManager")
+    @Transactional(readOnly = true)
     public List<GroupListForSaveMemoryResponseDto> findGroupListLoginUserParticipateForMemoryCreate(Long userSeq) {
         return userGroupQueryRepository.getUserGroupListForMemoryEnroll(userSeq);
     }
-
 
     @Transactional
     public UserGroup saveGroup(CreateGroupRequestDto createGroupRequestDto) {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/GroupAndUser.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/GroupAndUser.java
@@ -1,22 +1,19 @@
 package cmc.mellyserver.mellycore.group.domain;
 
+import cmc.mellyserver.mellycore.common.util.jpa.JpaBaseEntity;
 import cmc.mellyserver.mellycore.user.domain.User;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-/**
- * GroupAndUser.java
- *
- * @author jemlog
- */
-@Entity
-@NoArgsConstructor
-@Table(name = "tb_group_and_user")
 @Getter
-public class GroupAndUser {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_group_and_user")
+public class GroupAndUser extends JpaBaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -40,6 +37,5 @@ public class GroupAndUser {
     public static GroupAndUser of(User user, UserGroup group) {
         return GroupAndUser.builder().user(user).group(group).build();
     }
-
 }
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/UserGroup.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/UserGroup.java
@@ -38,6 +38,7 @@ public class UserGroup extends JpaBaseEntity {
     @CollectionTable
     private Set<Long> groupManagers = new HashSet<>();
 
+
     @Enumerated(EnumType.STRING)
     @Column(name = "group_type", nullable = false)
     private GroupType groupType;
@@ -52,6 +53,7 @@ public class UserGroup extends JpaBaseEntity {
         this.groupType = groupType;
         this.groupIcon = groupIcon;
     }
+
 
     public void remove(Long userId) {
 
@@ -70,7 +72,7 @@ public class UserGroup extends JpaBaseEntity {
         this.groupType = groupType;
         this.groupIcon = groupIcon;
     }
-    
+
     public void assignGroupManager(Long userId) {
         this.groupManagers.add(userId);
     }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/repository/UserGroupQueryRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/repository/UserGroupQueryRepository.java
@@ -62,9 +62,8 @@ public class UserGroupQueryRepository {
     }
 
     @Transactional(readOnly = true)
-    public List<GroupLoginUserParticipatedResponseDto> getGroupListLoginUserParticipate(
-            Long userSeq) {
-        System.out.println("쿼리 시작");
+    public List<GroupLoginUserParticipatedResponseDto> getGroupListLoginUserParticipate(Long userSeq) {
+
         List<GroupAndUser> results = query.select(groupAndUser)
                 .from(groupAndUser)
                 .join(groupAndUser.group, userGroup).fetchJoin()

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/repository/dto/GroupLoginUserParticipatedResponseDto.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/domain/repository/dto/GroupLoginUserParticipatedResponseDto.java
@@ -1,11 +1,10 @@
 package cmc.mellyserver.mellycore.group.domain.repository.dto;
 
 import cmc.mellyserver.mellycommon.enums.GroupType;
-import cmc.mellyserver.mellycore.user.domain.repository.UserDto;
+import cmc.mellyserver.mellycore.group.domain.GroupAndUser;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
 
 @Data
 @NoArgsConstructor
@@ -14,28 +13,23 @@ public class GroupLoginUserParticipatedResponseDto {
     private Long groupId;
     private int groupIcon;
     private String groupName;
-    private List<UserDto> users;
     private GroupType groupType;
-    private String invitationLink;
 
-    public GroupLoginUserParticipatedResponseDto(Long groupId, int groupIcon, String groupName,
-                                                 GroupType groupType,
-                                                 String invitationLink) {
+
+    @Builder
+    public GroupLoginUserParticipatedResponseDto(Long groupId, int groupIcon, String groupName, GroupType groupType) {
         this.groupId = groupId;
         this.groupIcon = groupIcon;
         this.groupName = groupName;
         this.groupType = groupType;
-        this.invitationLink = invitationLink;
     }
 
-    public GroupLoginUserParticipatedResponseDto(Long groupId, int groupIcon, String groupName,
-                                                 List<UserDto> users,
-                                                 GroupType groupType, String invitationLink) {
-        this.groupId = groupId;
-        this.groupIcon = groupIcon;
-        this.groupName = groupName;
-        this.users = users;
-        this.groupType = groupType;
-        this.invitationLink = invitationLink;
+    public static GroupLoginUserParticipatedResponseDto of(GroupAndUser groupAndUser) {
+        return GroupLoginUserParticipatedResponseDto.builder()
+                .groupId(groupAndUser.getGroup().getId())
+                .groupIcon(groupAndUser.getGroup().getGroupIcon())
+                .groupName(groupAndUser.getGroup().getGroupName())
+                .groupType(groupAndUser.getGroup().getGroupType())
+                .build();
     }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryService.java
@@ -57,7 +57,7 @@ public class MemoryService {
     private final GroupAndUserRepository groupAndUserRepository;
 
 
-    @Cacheable(value = "memory", key = "'memoryId'")
+    @Cacheable(value = "memory", key = "#memoryId", cacheManager = "redisCacheManager")
     @Transactional(readOnly = true)
     public MemoryResponseDto findMemoryByMemoryId(Long userSeq, Long memoryId) {
         return memoryQueryRepository.getMemoryByMemoryId(userSeq, memoryId);
@@ -214,7 +214,7 @@ public class MemoryService {
     }
 
 
-    @CacheEvict(value = "memory")
+    @CacheEvict(value = "memory", key = "#memoryId", cacheManager = "redisCacheManager")
     @Transactional
     public void removeMemory(Long userSeq, Long memoryId) {
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/Memory.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/Memory.java
@@ -1,63 +1,56 @@
 package cmc.mellyserver.mellycore.memory.domain;
 
+import cmc.mellyserver.mellycommon.enums.DeleteStatus;
 import cmc.mellyserver.mellycommon.enums.GroupType;
 import cmc.mellyserver.mellycommon.enums.OpenType;
 import cmc.mellyserver.mellycore.common.util.jpa.JpaBaseEntity;
 import cmc.mellyserver.mellycore.memory.domain.vo.GroupInfo;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import javax.persistence.CascadeType;
-import javax.persistence.CollectionTable;
-import javax.persistence.Column;
-import javax.persistence.ElementCollection;
-import javax.persistence.Embedded;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Index;
-import javax.persistence.JoinColumn;
-import javax.persistence.Lob;
-import javax.persistence.OneToMany;
-import javax.persistence.PrePersist;
-import javax.persistence.Table;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
-@AllArgsConstructor
-@Table(name = "tb_memory", indexes = {
-        @Index(name = "idx__groupType", columnList = "groupType"),
-        @Index(name = "idx__stars", columnList = "stars"),
-        @Index(name = "id__openType", columnList = "openType")
-})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_memory")
 public class Memory extends JpaBaseEntity {
 
-    @Embedded
-    GroupInfo groupInfo;
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "memory_id")
     private Long id;
+
+    @Column(name = "stars")
     private Long stars;
+
+    @Column(name = "user_id")
     private Long userId;
+
+    @Column(name = "place_id")
     private Long placeId;
+
+    @Column(name = "title")
     private String title;
+
+    @Column(name = "content")
     @Lob
     private String content;
+
     @Enumerated(EnumType.STRING)
+    @Column(name = "open_type")
     private OpenType openType;
 
-    private boolean isDelete;
+    @Column(name = "is_deleted")
+    private DeleteStatus is_deleted;
+
+    @Embedded
+    GroupInfo groupInfo;
 
     private boolean isReported = false;
 
@@ -70,14 +63,12 @@ public class Memory extends JpaBaseEntity {
     @CollectionTable(
             name = "tb_keywords_table",
             joinColumns = @JoinColumn(name = "memory_id"))
-    @Column(name = "keyword") // 컬럼명 지정 (예외)
+    @Column(name = "keyword")
     private List<String> keyword = new ArrayList<>();
 
     @Builder
-    public Memory(Long stars, GroupInfo groupInfo, Long userId, Long placeId, String title,
-            String content,
-            OpenType openType,
-            LocalDateTime visitedDate, boolean isDelete) {
+    public Memory(Long stars, GroupInfo groupInfo, Long userId, Long placeId, String title, String content, OpenType openType, LocalDateTime visitedDate) {
+
         this.stars = stars;
         this.groupInfo = groupInfo;
         this.title = title;
@@ -86,16 +77,15 @@ public class Memory extends JpaBaseEntity {
         this.content = content;
         this.openType = openType;
         this.visitedDate = visitedDate;
-        this.isDelete = isDelete;
     }
 
     @PrePersist
     public void init() {
-        this.isDelete = false;
+        this.is_deleted = DeleteStatus.N;
     }
 
     public void delete() {
-        this.isDelete = true;
+        this.is_deleted = DeleteStatus.Y;
     }
 
     public void setUserId(Long userId) {
@@ -106,9 +96,8 @@ public class Memory extends JpaBaseEntity {
         this.placeId = placeId;
     }
 
-    public void updateMemory(String title, String content, List<String> keyword, Long groupId,
-            GroupType groupType,
-            String groupName, OpenType openType, LocalDateTime visitedDate, Long star) {
+    public void updateMemory(String title, String content, List<String> keyword, Long groupId, GroupType groupType, String groupName, OpenType openType, LocalDateTime visitedDate, Long star) {
+
         this.title = title;
         this.content = content;
         this.keyword = keyword;
@@ -119,6 +108,7 @@ public class Memory extends JpaBaseEntity {
     }
 
     public void setMemoryImages(List<MemoryImage> memoryImages) {
+
         this.memoryImages = memoryImages;
         for (MemoryImage memoryImage : memoryImages) {
             memoryImage.setMemory(this);

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/MemoryImage.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/MemoryImage.java
@@ -1,61 +1,51 @@
 package cmc.mellyserver.mellycore.memory.domain;
 
-import java.util.Objects;
-
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
-
+import cmc.mellyserver.mellycore.common.util.jpa.JpaBaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "tb_memory_image")
+import javax.persistence.*;
+import java.util.Objects;
+
 @Getter
-public class MemoryImage {
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_memory_image")
+public class MemoryImage extends JpaBaseEntity {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "memory_image_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_image_id")
+    private Long id;
 
-	private String imagePath;
+    @Column(name = "image_path")
+    private String imagePath;
 
-	@ManyToOne
-	@JoinColumn(name = "memory_id")
-	private Memory memory;
+    @ManyToOne
+    @JoinColumn(name = "memory_id")
+    private Memory memory;
 
-	public MemoryImage(String imagePath) {
-		this.imagePath = imagePath;
-	}
+    public MemoryImage(String imagePath) {
+        this.imagePath = imagePath;
+    }
 
-	public MemoryImage(Long id) {
-		this.id = id;
-	}
+    public void setMemory(Memory memory) {
+        this.memory = memory;
+    }
 
-	public void setMemory(Memory memory) {
-		this.memory = memory;
-	}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (o == null || getClass() != o.getClass())
+            return false;
+        MemoryImage that = (MemoryImage) o;
+        return Objects.equals(id, that.id);
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o)
-			return true;
-		if (o == null || getClass() != o.getClass())
-			return false;
-		MemoryImage that = (MemoryImage)o;
-		return Objects.equals(id, that.id);
-	}
-
-	@Override
-	public int hashCode() {
-		return Objects.hash(id);
-	}
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/repository/MemoryQueryRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/repository/MemoryQueryRepository.java
@@ -182,6 +182,7 @@ public class MemoryQueryRepository {
                 .from(memory)
                 .leftJoin(place).on(place.id.eq(memory.placeId))
                 .where(
+                        memory.placeId.eq(placeId),
                         memory.userId.ne(userSeq), // 내가 작성자인 메모리
                         eqGroup(groupType)// 그룹 타입 필터링 용
                 )
@@ -218,6 +219,7 @@ public class MemoryQueryRepository {
                                                                 userSeq))
                                         )).distinct()
                         ),
+                        memory.placeId.eq(placeId),
                         memory.userId.ne(userSeq),
                         eqGroup(groupType),
                         memory.openType.ne(OpenType.PRIVATE)

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/notification/domain/Notification.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/notification/domain/Notification.java
@@ -1,55 +1,55 @@
 package cmc.mellyserver.mellycore.notification.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
-
 import cmc.mellyserver.mellycommon.enums.NotificationType;
 import cmc.mellyserver.mellycore.common.util.jpa.JpaBaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Entity
+import javax.persistence.*;
+
+
 @Getter
-@Table(name = "tb_notification")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_notification")
 public class Notification extends JpaBaseEntity {
 
-	@Enumerated(EnumType.STRING)
-	NotificationType title;
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "notification_id")
-	private Long id;
-	private String message;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long id;
 
-	private boolean checked;
+    @Column(name = "message")
+    private String message;
 
-	private Long userId;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "title")
+    NotificationType title;
 
-	private Long memoryId;
+    @Column(name = "checked")
+    private Boolean checked;
 
-	public Notification(NotificationType title, String message, boolean checked, Long userId, Long memoryId) {
-		this.title = title;
-		this.message = message;
-		this.checked = checked;
-		this.userId = userId;
-		this.memoryId = memoryId;
-	}
+    @Column(name = "user_id")
+    private Long userId;
 
-	public static Notification createNotification(NotificationType title, String message, boolean checked,
-		Long memoryId, Long userId) {
-		Notification notification = new Notification(title, message, checked, userId, memoryId);
-		return notification;
-	}
+    @Column(name = "memory_id")
+    private Long memoryId;
 
-	public void checkNotification(boolean check) {
-		this.checked = check;
-	}
+    public Notification(NotificationType title, String message, boolean checked, Long userId, Long memoryId) {
+        this.title = title;
+        this.message = message;
+        this.checked = checked;
+        this.userId = userId;
+        this.memoryId = memoryId;
+    }
+
+    public static Notification createNotification(NotificationType title, String message, boolean checked, Long memoryId, Long userId) {
+
+        return new Notification(title, message, checked, userId, memoryId);
+    }
+
+    public void checkNotification(boolean check) {
+        this.checked = check;
+    }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/place/application/PlaceService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/place/application/PlaceService.java
@@ -34,7 +34,9 @@ public class PlaceService {
 
     private final MemoryQueryRepository memoryQueryRepository;
 
-
+    /*
+    좌표 기반 검색으로 개선 필요
+     */
     @Transactional(readOnly = true)
     public List<MarkedPlaceResponseDto> displayMarkedPlace(Long userSeq, GroupType groupType) {
 
@@ -43,9 +45,13 @@ public class PlaceService {
                 .collect(Collectors.toList());
     }
 
-
+    /*
+    캐싱 적용 여부 : 불가능
+    이유 : 반환 DTO에 다른 유저가 작성한 메모리 수가 포함된다. 유저가 대규모로 유입되면 데이터 갱신이 자주 발생하여 캐시 효율성이 적다고 판단
+     */
     @Transactional(readOnly = true)
     public PlaceResponseDto findPlaceByPlaceId(Long userSeq, Long placeId) {
+
         Place place = placeRepository.findById(placeId).orElseThrow(() -> {
             throw new GlobalBadRequestException(ErrorCode.NO_SUCH_PLACE);
         });
@@ -60,9 +66,13 @@ public class PlaceService {
                 place.getPlaceImage());
     }
 
-
+    /*
+    캐싱 적용 여부 : 불가능
+    이유 : 반환 DTO에 다른 유저가 작성한 메모리 수가 포함된다. 유저가 대규모로 유입되면 데이터 갱신이 자주 발생하여 캐시 효율성이 적다고 판단
+     */
     @Transactional(readOnly = true)
     public PlaceResponseDto findPlaceByPosition(Long userSeq, Double lat, Double lng) {
+
         Optional<Place> optPlace = placeRepository.findPlaceByPosition(new Position(lat, lng));
 
         if (optPlace.isEmpty()) {
@@ -79,9 +89,12 @@ public class PlaceService {
                 isCurrentLoginUserScraped, place.getPlaceCategory(), place.getPlaceName(), GroupType.ALL, place.getPlaceImage());
     }
 
-
+    /*
+    캐시 적용 여부 : 가능
+     */
     @Transactional(readOnly = true)
     public List<FindPlaceInfoByMemoryNameResponseDto> findPlaceInfoByMemoryName(Long userSeq, String memoryName) {
+
         return placeQueryRepository.searchPlaceByContainMemoryName(userSeq, memoryName);
     }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/place/application/PlaceService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/place/application/PlaceService.java
@@ -37,10 +37,9 @@ public class PlaceService {
 
     @Transactional(readOnly = true)
     public List<MarkedPlaceResponseDto> displayMarkedPlace(Long userSeq, GroupType groupType) {
-        List<Place> placeUserMemoryExist = placeQueryRepository.getPlaceUserMemoryExist(userSeq);
-        return placeUserMemoryExist.stream()
-                .map(each -> new MarkedPlaceResponseDto(each.getPosition(), null, each.getId(),
-                        null))
+
+        List<Place> placeUserMemoryExist = placeQueryRepository.getPlaceUserMemoryExist(userSeq, groupType);
+        return placeUserMemoryExist.stream().map(each -> new MarkedPlaceResponseDto(each.getPosition(), null, each.getId(), null))
                 .collect(Collectors.toList());
     }
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/Place.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/Place.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "tb_place")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_place")
 public class Place extends JpaBaseEntity {
 
     @Id
@@ -27,11 +27,14 @@ public class Place extends JpaBaseEntity {
     @Column(name = "place_name")
     private String placeName;
 
+    @Column(name = "place_image")
     private String placeImage;
 
+    @Column(name = "place_category")
     private String placeCategory;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "is_deleted")
     private DeleteStatus isDeleted;
 
     @Builder
@@ -43,7 +46,6 @@ public class Place extends JpaBaseEntity {
         this.placeCategory = placeCategory;
         this.isDeleted = isDeleted;
     }
-
 
     @PrePersist
     public void init() {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/repository/PlaceQueryRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/repository/PlaceQueryRepository.java
@@ -36,7 +36,7 @@ public class PlaceQueryRepository {
     }
 
 
-    public List<Place> getPlaceUserMemoryExist(Long userSeq) {
+    public List<Place> getPlaceUserMemoryExist(Long userSeq, GroupType groupType) {
 
         return query.select(place)
                 .from(place)

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/repository/PlaceQueryRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/place/domain/repository/PlaceQueryRepository.java
@@ -49,18 +49,16 @@ public class PlaceQueryRepository {
 
     }
 
-    public List<FindPlaceInfoByMemoryNameResponseDto> searchPlaceByContainMemoryName(Long userSeq,
-                                                                                     String memoryName) {
+    public List<FindPlaceInfoByMemoryNameResponseDto> searchPlaceByContainMemoryName(Long userSeq, String memoryName) {
 
         return query.select(
-                        Projections.constructor(FindPlaceInfoByMemoryNameResponseDto.class, memory.placeId,
-                                memory.title))
+                        Projections.constructor(FindPlaceInfoByMemoryNameResponseDto.class, memory.placeId, memory.title))
                 .from(memory)
                 .where(
-                        memory.userId.eq(userSeq),  // 본인이 가지고 있는 메모리
-                        memory.isReported.isFalse(),      // 신고되지 않은 메모리
-                        memory.isDelete.isFalse(),        // 삭제 되지 않은 메모리
-                        memory.title.contains(memoryName)) // 메모리 제목으로 검색하는 로직
+                        memory.userId.eq(userSeq),
+                        memory.isDelete.isFalse(),
+                        memory.title.contains(memoryName)
+                )
                 .distinct().fetch();
     }
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/application/PlaceScrapService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/application/PlaceScrapService.java
@@ -36,13 +36,22 @@ public class PlaceScrapService {
 
     private final AuthenticatedUserChecker authenticatedUserChecker;
 
+    /*
+    캐싱 적용 가능 여부 : 불가능
+    이유 : 반환 하는 DTO에 다른 사람이 해당 장소에 작성한 메모리 개수가 포함된다. 대규모 사용자가 유입될 시 자주 업데이트 되는 항목이므로 캐싱 효율성이 적다.
+     */
     @Transactional(readOnly = true)
     public Slice<ScrapedPlaceResponseDto> findScrapedPlace(Pageable pageable, Long userSeq, ScrapType scrapType) {
+
         return placeScrapQueryRepository.getUserScrapedPlace(pageable, userSeq, scrapType);
     }
 
+    /*
+    캐싱 적용 가능 여부 : 가능
+    */
     @Transactional(readOnly = true)
     public List<PlaceScrapCountResponseDto> countByPlaceScrapType(Long userSeq) {
+
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(userSeq);
         return placeScrapQueryRepository.getScrapedPlaceGrouping(user.getUserSeq());
     }
@@ -56,7 +65,6 @@ public class PlaceScrapService {
         placeScrapRepository.save(PlaceScrap.createScrap(user, place, createPlaceScrapRequestDto.getScrapType()));
     }
 
-
     @Transactional
     public void removeScrap(Long userSeq, Double lat, Double lng) {
 
@@ -68,12 +76,14 @@ public class PlaceScrapService {
     }
 
     private void checkDuplicatedScrap(Long userSeq, Long placeId) {
+
         placeScrapRepository.findByUserUserSeqAndPlaceId(userSeq, placeId).ifPresent(x -> {
             throw new GlobalBadRequestException(ErrorCode.DUPLICATE_SCRAP);
         });
     }
 
     private void checkExistScrap(Long userSeq, Long placeId) {
+
         placeScrapRepository.findByUserUserSeqAndPlaceId(userSeq, placeId).orElseThrow(() -> {
             throw new GlobalBadRequestException(ErrorCode.NOT_EXIST_SCRAP);
         });

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/domain/PlaceScrap.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/domain/PlaceScrap.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "tb_place_scrap")
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "tb_place_scrap")
 public class PlaceScrap extends JpaBaseEntity {
 
     @Id
@@ -30,19 +30,9 @@ public class PlaceScrap extends JpaBaseEntity {
     @JoinColumn(name = "place_id")
     private Place place;
 
-//	private Long userId;
-//
-//	private Long placeId;
-
     @Enumerated(EnumType.STRING)
+    @Column(name = "scrap_type", nullable = false)
     private ScrapType scrapType;
-
-//    @Builder
-//    public PlaceScrap(Long userId, Long placeId, ScrapType scrapType) {
-//        this.userId = userId;
-//        this.placeId = placeId;
-//        this.scrapType = scrapType;
-//    }
 
     @Builder
     public PlaceScrap(User user, Place place, ScrapType scrapType) {
@@ -54,7 +44,4 @@ public class PlaceScrap extends JpaBaseEntity {
     public static PlaceScrap createScrap(User user, Place place, ScrapType scrapType) {
         return new PlaceScrap(user, place, scrapType);
     }
-//	public static PlaceScrap createScrap(User user, Place place, ScrapType scrapType) {
-//		return new PlaceScrap(user.getUserSeq(), place.getId(), scrapType);
-//	}
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/domain/repository/PlaceScrapJDBCRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/scrap/domain/repository/PlaceScrapJDBCRepository.java
@@ -2,6 +2,7 @@ package cmc.mellyserver.mellycore.scrap.domain.repository;
 
 import cmc.mellyserver.mellycore.place.domain.Place;
 import cmc.mellyserver.mellycore.scrap.domain.PlaceScrap;
+import cmc.mellyserver.mellycore.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -49,6 +50,41 @@ public class PlaceScrapJDBCRepository {
                     @Override
                     public int getBatchSize() {
                         return placeScraps.size();
+                    }
+                });
+    }
+
+
+    //       .randomize(email(), new StringRandomizer()) // 내가 강제로 주입받은 걸로 바꿀 수 있다.
+//            .randomize(password(), () -> password)
+//            .randomize(ageGroup(), new EnumRandomizer<>(AgeGroup .class))
+//            .randomize(gender(), new EnumRandomizer<>(Gender .class))
+//            .randomize(nickname(), new StringRandomizer())
+//            .randomize(provider(), new EnumRandomizer<>(Provider .class))
+//            .randomize(role_type(), new EnumRandomizer<>(RoleType .class))
+//            .randomize(user_id(), new StringRandomizer())
+//            .randomize(userStatus(), new EnumRandomizer<>(UserStatus .class));
+    public void saveUser(List<User> user) {
+
+        jdbcTemplate.batchUpdate("insert into tb_user(email, password, age_group,gender, nickname, provider, role_type, user_id, user_status) " +
+                        "values(?,?,?,?,?,?,?,?,?)",
+                new BatchPreparedStatementSetter() {
+                    @Override
+                    public void setValues(PreparedStatement ps, int i) throws SQLException {
+                        ps.setString(1, user.get(i).getEmail());
+                        ps.setString(2, user.get(i).getPassword());
+                        ps.setString(3, user.get(i).getAgeGroup().name());
+                        ps.setString(4, user.get(i).getGender().name());
+                        ps.setString(5, user.get(i).getNickname());
+                        ps.setString(6, user.get(i).getProvider().name());
+                        ps.setString(7, user.get(i).getRoleType().name());
+                        ps.setString(8, user.get(i).getUserId());
+                        ps.setString(9, user.get(i).getUserStatus().name());
+                    }
+
+                    @Override
+                    public int getBatchSize() {
+                        return user.size();
                     }
                 });
     }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
@@ -26,11 +26,18 @@ public class UserProfileService {
 
     private final UserRepository userRepository;
 
+    /**
+     * 캐싱 적용 여부 : 가능
+     */
     @Transactional(readOnly = true)
     public Integer checkImageStorageVolumeLoginUserUse(String username) {
         return awsService.calculateImageVolume("mellyimage", username).intValue();
     }
 
+    /**
+     * 캐싱 적용 여부 : 불가능
+     * 이유 : 프로필 정보를 수정하기 위해 조회하는 데이터는 항상 최신성이 보장되야 한다. 따라서 캐시 적용 불가능하다.
+     */
     @Transactional(readOnly = true)
     public ProfileUpdateFormResponseDto getLoginUserProfileDataForUpdate(Long userSeq) {
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
@@ -33,10 +33,9 @@ public class UserProfileService {
 
     @Transactional(readOnly = true)
     public ProfileUpdateFormResponseDto getLoginUserProfileDataForUpdate(Long userSeq) {
+
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(userSeq);
-        return new ProfileUpdateFormResponseDto(user.getProfileImage(), user.getNickname(),
-                user.getGender(),
-                user.getAgeGroup());
+        return new ProfileUpdateFormResponseDto(user.getProfileImage(), user.getNickname(), user.getGender(), user.getAgeGroup());
     }
 
     @Transactional(readOnly = true)
@@ -50,6 +49,7 @@ public class UserProfileService {
 
     @Transactional
     public void updateLoginUserProfile(ProfileUpdateRequestDto profileUpdateRequestDto) {
+
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(profileUpdateRequestDto.getUserSeq());
         user.updateProfile(profileUpdateRequestDto.getNickname(), profileUpdateRequestDto.getGender(), profileUpdateRequestDto.getAgeGroup());
 

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserSurveyService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserSurveyService.java
@@ -16,13 +16,16 @@ public class UserSurveyService {
     private final AuthenticatedUserChecker authenticatedUserChecker;
     private final SurveyRecommender surveyRecommender;
 
-    @Transactional(readOnly = true)
+    /*
+    readOnly 옵션 미적용 사유 : 설문 조사 조회 시나리오 상, 설문 조사를 생성 후 바로 추천 결과를 보여준다. 실제 추천 서비스가 적용될 시 시간 차가 존재하기에 레플리카로부터 데이터를 받아와도 되지만,
+                            레플리카 렉을 고려하여 소스 DB로 부터 데이터를 가져온다.
+     */
+    @Transactional
     public SurveyRecommendResponseDto getSurveyResult(Long userSeq) {
 
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(userSeq);
         return surveyRecommender.getRecommend(user.getRecommend().getRecommendGroup());
     }
-
 
     @Transactional
     public void createSurvey(SurveyRequestDto surveyRequestDto) {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserSurveyService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserSurveyService.java
@@ -18,6 +18,7 @@ public class UserSurveyService {
 
     @Transactional(readOnly = true)
     public SurveyRecommendResponseDto getSurveyResult(Long userSeq) {
+
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(userSeq);
         return surveyRecommender.getRecommend(user.getRecommend().getRecommendGroup());
     }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/domain/User.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/domain/User.java
@@ -3,19 +3,20 @@ package cmc.mellyserver.mellycore.user.domain;
 import cmc.mellyserver.mellycommon.enums.*;
 import cmc.mellyserver.mellycore.common.util.jpa.JpaBaseEntity;
 import cmc.mellyserver.mellycore.user.domain.vo.Recommend;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
-@Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
 @Table(name = "tb_user")
 public class User extends JpaBaseEntity {
-
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -46,13 +47,13 @@ public class User extends JpaBaseEntity {
     @Column(name = "fcm_token")
     private String fcmToken;
 
-    @Column(name = "enable_app_push", nullable = false)
+    @Column(name = "enable_app_push")
     private boolean enableAppPush;
 
-    @Column(name = "enable_comment_like", nullable = false)
+    @Column(name = "enable_comment_like")
     private boolean enableCommentLike;
 
-    @Column(name = "enable_comment", nullable = false)
+    @Column(name = "enable_comment")
     private boolean enableComment;
 
     @Column(name = "password_init_date")
@@ -92,12 +93,9 @@ public class User extends JpaBaseEntity {
     }
 
     @Builder
-    private User(Long userSeq, String email, String password, RoleType roleType, String profileImage,
-                 AgeGroup ageGroup, Gender gender, UserStatus userStatus,
-                 String fcmToken, String uid, Provider provider, String nickname, boolean enableAppPush,
-                 PasswordExpired passwordExpired, LocalDateTime passwordInitDate,
+    private User(Long userSeq, String email, String password, RoleType roleType, String profileImage, AgeGroup ageGroup, Gender gender, UserStatus userStatus,
+                 String fcmToken, String uid, Provider provider, String nickname, boolean enableAppPush, PasswordExpired passwordExpired, LocalDateTime passwordInitDate,
                  boolean enableCommentLike, boolean enableComment) {
-
 
         this.userSeq = userSeq;
         this.email = email;
@@ -118,8 +116,7 @@ public class User extends JpaBaseEntity {
         this.passwordInitDate = passwordInitDate;
     }
 
-    public void updateUser(String nickname, Gender gender, String profileImage, AgeGroup ageGroup,
-                           boolean enableAppPush, boolean enableCommentLike, boolean enableComment) {
+    public void updateUser(String nickname, Gender gender, String profileImage, AgeGroup ageGroup, boolean enableAppPush, boolean enableCommentLike, boolean enableComment) {
         this.nickname = nickname;
         this.gender = gender;
         this.profileImage = profileImage;
@@ -187,7 +184,6 @@ public class User extends JpaBaseEntity {
         this.passwordInitDate = localDateTime;
         return this;
     }
-
 
     private boolean isDefaultEmailUser() {
         return !Objects.isNull(this.provider) && this.provider.equals(Provider.DEFAULT);

--- a/melly-core/src/main/resources/application-local.yml
+++ b/melly-core/src/main/resources/application-local.yml
@@ -1,0 +1,56 @@
+spring:
+  redis:
+    host: localhost
+    port: 6379
+  jpa:
+    open-in-view: false
+    hibernate:
+      ddl-auto: none
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+        show_sql: true
+        format_sql: true
+
+  servlet:
+    multipart:
+      max-request-size: 10MB
+      max-file-size: 10MB
+
+  datasource:
+    source:
+      jdbc-url: jdbc:mysql://192.168.0.8:3307/melly_db
+      username: root
+      password: 1234
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    replica1:
+      jdbc-url: jdbc:mysql://192.168.0.8:3308/melly_db
+      username: root
+      password: 1234
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      maximum-pool-size: 10
+      minimum-idle: 10
+#    replica2:
+#      jdbc-url: jdbc:mysql://192.168.0.8:3309/melly_db
+#      username: root
+#      password: 1234
+#      driver-class-name: com.mysql.cj.jdbc.Driver
+
+app:
+  auth:
+    tokenExpiry: 1000000
+    tokenSecret: Y21jMTF0aGFub3RoZXJjbWNzdXJmbWF0ZWNtYzExdGhhbm90aGVyY21jc3VyZm1hdGUfwegwegewfwwgwegwggsfgergtrr
+
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    s3:
+      bucket: mellyimage
+    credentials:
+      access-key: AKIAUNVVDKLX73VXJ35V
+      secret-key: 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

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/common/fixtures/PlaceScrapFixtureFactory.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/common/fixtures/PlaceScrapFixtureFactory.java
@@ -1,13 +1,13 @@
 package cmc.mellyserver.mellycore.unit.common.fixtures;
 
-import cmc.mellyserver.mellycommon.enums.ScrapType;
+import cmc.mellyserver.mellycommon.enums.*;
 import cmc.mellyserver.mellycore.place.domain.Place;
 import cmc.mellyserver.mellycore.scrap.domain.PlaceScrap;
 import cmc.mellyserver.mellycore.user.domain.User;
 import org.jeasy.random.EasyRandom;
 import org.jeasy.random.EasyRandomParameters;
 import org.jeasy.random.randomizers.misc.EnumRandomizer;
-import org.jeasy.random.randomizers.range.LongRangeRandomizer;
+import org.jeasy.random.randomizers.text.StringRandomizer;
 
 import java.lang.reflect.Field;
 import java.util.function.Predicate;
@@ -16,10 +16,10 @@ import static org.jeasy.random.FieldPredicates.*;
 
 
 public class PlaceScrapFixtureFactory {
-    public static PlaceScrap create() {
-        EasyRandomParameters parameter = getEasyRandomParameters();
-        return new EasyRandom(parameter).nextObject(PlaceScrap.class);
-    }
+//    public static PlaceScrap create() {
+//        EasyRandomParameters parameter = getEasyRandomParameters();
+//        return new EasyRandom(parameter).nextObject(PlaceScrap.class);
+//    }
 
 //    public static Post create(Long memberId, LocalDate createdDate) {
 //        EasyRandomParameters parameter = getEasyRandomParameters();
@@ -30,32 +30,67 @@ public class PlaceScrapFixtureFactory {
 //        return new EasyRandom(parameter).nextObject(Post.class);
 //    }
 
-//    public static Post create(Long memberId, LocalDate start, LocalDate end) {
-//        EasyRandomParameters parameter = getEasyRandomParameters();
-//        parameter
-//                .randomize(memberId(), () -> memberId) // 내가 강제로 주입받은 걸로 바꿀 수 있다.
-//                .randomize(createdDate(), new LocalDateRangeRandomizer(start, end));
-//
-//        return new EasyRandom(parameter).nextObject(Post.class);
-//    }
-
-    // 사용자는 하나, 장소는 모두 다르게, scrapType은 고르게
-    public static EasyRandom get() {
-
-        EasyRandomParameters parameter = getEasyRandomParameters();
-
+    public static EasyRandom createUser(String password) {
+        EasyRandomParameters parameter = new EasyRandomParameters();
         parameter
-                .randomize(user(), () -> User.builder().userSeq(1L).nickname("jemin").build())
-                .randomize(scrapType(), new EnumRandomizer<>(ScrapType.class));
+                .excludeField(named("id"))
+                .randomize(email(), new StringRandomizer()) // 내가 강제로 주입받은 걸로 바꿀 수 있다.
+                .randomize(password(), () -> password)
+                .randomize(ageGroup(), new EnumRandomizer<>(AgeGroup.class))
+                .randomize(gender(), new EnumRandomizer<>(Gender.class))
+                .randomize(nickname(), new StringRandomizer())
+                .randomize(provider(), new EnumRandomizer<>(Provider.class))
+                .randomize(role_type(), new EnumRandomizer<>(RoleType.class))
+                .randomize(user_id(), new StringRandomizer())
+                .randomize(userStatus(), new EnumRandomizer<>(UserStatus.class));
+
         return new EasyRandom(parameter);
     }
 
-    private static EasyRandomParameters getEasyRandomParameters() {
-        return new EasyRandomParameters()
-                .excludeField(named("id"))
-                .stringLengthRange(1, 100)
-                .randomize(Long.class, new LongRangeRandomizer(1L, 10000L));
-    }
+//    public static EasyRandom createMemory() {
+//        EasyRandomParameters parameter = new EasyRandomParameters();
+//        parameter
+//                .excludeField(named("id"))
+//                .randomize(email(), new StringRandomizer()) // 내가 강제로 주입받은 걸로 바꿀 수 있다.
+//                .randomize(password(), () -> password)
+//                .randomize(ageGroup(), new EnumRandomizer<>(AgeGroup.class))
+//                .randomize(gender(), new EnumRandomizer<>(Gender.class))
+//                .randomize(nickname(), new StringRandomizer())
+//                .randomize(provider(), new EnumRandomizer<>(Provider.class))
+//                .randomize(role_type(), new EnumRandomizer<>(RoleType.class))
+//                .randomize(user_id(), new StringRandomizer())
+//                .randomize(userStatus(), new EnumRandomizer<>(UserStatus.class));
+//
+//        return new EasyRandom(parameter);
+//    }
+
+//    // 사용자는 하나, 장소는 모두 다르게, scrapType은 고르게
+//    public static EasyRandom get() {
+//
+//        EasyRandomParameters parameter = getEasyRandomParameters();
+//
+//        parameter
+//                .randomize(user(), () -> User.builder().userSeq(1L).nickname("jemin").build())
+//                .randomize(scrapType(), new EnumRandomizer<>(ScrapType.class));
+//        return new EasyRandom(parameter);
+//    }
+
+//    public static EasyRandom getUser() {
+//
+//        EasyRandomParameters parameter = getEasyRandomParameters();
+//
+//        parameter
+//                .randomize(user(), () -> User.builder().userSeq(1L).nickname("jemin").build())
+//                .randomize(scrapType(), new EnumRandomizer<>(ScrapType.class));
+//        return new EasyRandom(parameter);
+//    }
+
+//    private static EasyRandomParameters getEasyRandomParameters() {
+//        return new EasyRandomParameters()
+//                .excludeField(named("id"))
+//                .stringLengthRange(1, 100)
+//                .randomize(Long.class, new LongRangeRandomizer(1L, 10000L));
+//    }
 
     private static Predicate<Field> user() {
         return named("user").and(ofType(User.class));
@@ -68,4 +103,46 @@ public class PlaceScrapFixtureFactory {
     private static Predicate<Field> scrapType() {
         return named("scrapType").and(ofType(ScrapType.class)).and(inClass(PlaceScrap.class));
     }
+
+    private static Predicate<Field> email() {
+        return named("email").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> password() {
+        return named("password").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> ageGroup() {
+        return named("ageGroup").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> gender() {
+        return named("gender").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> nickname() {
+        return named("nickname").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> provider() {
+        return named("provider").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> role_type() {
+        return named("roleType").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> user_id() {
+        return named("userId").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> place_id() {
+        return named("place_id").and(ofType(String.class));
+    }
+
+    private static Predicate<Field> userStatus() {
+        return named("userStatus").and(ofType(String.class));
+    }
+
+
 }

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/InfrastructureTestConfiguration.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/InfrastructureTestConfiguration.java
@@ -1,13 +1,14 @@
-package cmc.mellyserver.mellyapi.config;
+package cmc.mellyserver.mellycore.unit.config.mockapi;
 
-import cmc.mellyserver.mellyapi.common.mockapi.MockAwsService;
-import cmc.mellyserver.mellyapi.common.mockapi.MockFileUploader;
+
+import cmc.mellyserver.mellycore.common.aws.AwsService;
+import cmc.mellyserver.mellycore.common.aws.FileUploader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("test")
+@Profile("local")
 public class InfrastructureTestConfiguration {
 
     @Bean

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/MockAwsService.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/MockAwsService.java
@@ -1,4 +1,6 @@
-package cmc.mellyserver.mellyapi.common.mockapi;
+package cmc.mellyserver.mellycore.unit.config.mockapi;
+
+import cmc.mellyserver.mellycore.common.aws.AwsService;
 
 public class MockAwsService implements AwsService {
     @Override

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/MockFileUploader.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/config/mockapi/MockFileUploader.java
@@ -1,5 +1,6 @@
-package cmc.mellyserver.mellyapi.common.mockapi;
+package cmc.mellyserver.mellycore.unit.config.mockapi;
 
+import cmc.mellyserver.mellycore.common.aws.FileUploader;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/group/repository/UserGroupQueryRepositoryTest.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/group/repository/UserGroupQueryRepositoryTest.java
@@ -1,111 +1,90 @@
 package cmc.mellyserver.mellycore.unit.group.repository;
 
-import cmc.mellyserver.mellycommon.enums.GroupType;
-import cmc.mellyserver.mellycore.group.domain.GroupAndUser;
-import cmc.mellyserver.mellycore.group.domain.UserGroup;
-import cmc.mellyserver.mellycore.group.domain.repository.GroupAndUserRepository;
-import cmc.mellyserver.mellycore.group.domain.repository.GroupRepository;
-import cmc.mellyserver.mellycore.group.domain.repository.UserGroupQueryRepository;
-import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupListForSaveMemoryResponseDto;
-import cmc.mellyserver.mellycore.group.domain.repository.dto.GroupLoginUserParticipatedResponseDto;
-import cmc.mellyserver.mellycore.memory.domain.repository.MemoryRepository;
 import cmc.mellyserver.mellycore.unit.RepositoryTest;
-import cmc.mellyserver.mellycore.unit.common.fixtures.UserFixtures;
-import cmc.mellyserver.mellycore.user.domain.User;
-import cmc.mellyserver.mellycore.user.domain.repository.UserRepository;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class UserGroupQueryRepositoryTest extends RepositoryTest {
 
-    @Autowired
-    private UserGroupQueryRepository userGroupQueryRepository;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private MemoryRepository memoryRepository;
-
-    @Autowired
-    private GroupRepository groupRepository;
-
-    @Autowired
-    private GroupAndUserRepository groupAndUserRepository;
-    @Autowired
-    private TestEntityManager testEntityManager;
-
-    private User 제민;
-    private User 재현;
-
-    private List<UserGroup> groups;
-
-    @BeforeEach
-    void setUp() {
-
-        // given
-        User user1 = UserFixtures.제민();
-        제민 = userRepository.save(user1);
-
-        User user2 = UserFixtures.재현();
-        재현 = userRepository.save(user2);
-
-        UserGroup 친구_그룹 = UserGroup.builder().groupName("친구")
-                .groupType(GroupType.FRIEND).build();
-        GroupAndUser 친구_그룹_연결_1 = new GroupAndUser(제민, 친구_그룹);
-        GroupAndUser 친구_그룹_연결_2 = new GroupAndUser(재현, 친구_그룹);
-
-        UserGroup 가족_그룹 = UserGroup.builder().groupName("가족")
-                .groupType(GroupType.FAMILY).build();
-        GroupAndUser 가족_그룹_연결 = new GroupAndUser(제민, 가족_그룹);
-
-        UserGroup 동료_그룹 = UserGroup.builder().groupName("동료")
-                .groupType(GroupType.COMPANY).build();
-        GroupAndUser 동료_그룹_연결 = new GroupAndUser(제민, 동료_그룹);
-
-        groupAndUserRepository.saveAll(List.of(친구_그룹_연결_1, 친구_그룹_연결_2, 가족_그룹_연결, 동료_그룹_연결));
-        groups = groupRepository.saveAll(List.of(친구_그룹, 가족_그룹, 동료_그룹));
-
-        testEntityManager.flush();
-        testEntityManager.clear();
-
-
-    }
-
-    @DisplayName("메모리를 등록하기 위해서 내가 속한 그룹 리스트를 조회한다.")
-    @Test
-    void 메모리_등록을_위해서_내가_속한_그룹들을_조회한다() {
-
-        // when
-        List<GroupListForSaveMemoryResponseDto> userGroupListForMemoryEnroll = userGroupQueryRepository.getUserGroupListForMemoryEnroll(
-                제민.getUserSeq());
-
-        // then
-        assertThat(userGroupListForMemoryEnroll).hasSize(3);
-        assertThat(userGroupListForMemoryEnroll).extracting("groupName")
-                .containsExactlyInAnyOrder("친구", "가족", "동료");
-    }
-
-    @DisplayName("로그인한 유저가 속해있는 그룹을 모두 조회한다.")
-    @Test
-    void 로그인한_유저가_속해있는_그룹을_모두_반환한다() {
-
-        // when
-        List<GroupLoginUserParticipatedResponseDto> groupListLoginUserParticipate = userGroupQueryRepository.getGroupListLoginUserParticipate(
-                제민.getUserSeq());
-
-        // then
-        assertThat(groupListLoginUserParticipate).hasSize(3);
-        assertThat(groupListLoginUserParticipate).extracting("groupName")
-                .containsExactlyInAnyOrder("친구", "가족", "동료");
-    }
+//    @Autowired
+//    private UserGroupQueryRepository userGroupQueryRepository;
+//
+//    @Autowired
+//    private UserRepository userRepository;
+//
+//    @Autowired
+//    private MemoryRepository memoryRepository;
+//
+//    @Autowired
+//    private GroupRepository groupRepository;
+//
+//    @Autowired
+//    private GroupAndUserRepository groupAndUserRepository;
+//    @Autowired
+//    private TestEntityManager testEntityManager;
+//
+//    private User 제민;
+//    private User 재현;
+//
+//    private List<UserGroup> groups;
+//
+//    @BeforeEach
+//    void setUp() {
+//
+//        // given
+//        User user1 = UserFixtures.제민();
+//        제민 = userRepository.save(user1);
+//
+//        User user2 = UserFixtures.재현();
+//        재현 = userRepository.save(user2);
+//
+//        UserGroup 친구_그룹 = UserGroup.builder().groupName("친구")
+//                .groupType(GroupType.FRIEND).build();
+//        GroupAndUser 친구_그룹_연결_1 = new GroupAndUser(제민, 친구_그룹);
+//        GroupAndUser 친구_그룹_연결_2 = new GroupAndUser(재현, 친구_그룹);
+//
+//        UserGroup 가족_그룹 = UserGroup.builder().groupName("가족")
+//                .groupType(GroupType.FAMILY).build();
+//        GroupAndUser 가족_그룹_연결 = new GroupAndUser(제민, 가족_그룹);
+//
+//        UserGroup 동료_그룹 = UserGroup.builder().groupName("동료")
+//                .groupType(GroupType.COMPANY).build();
+//        GroupAndUser 동료_그룹_연결 = new GroupAndUser(제민, 동료_그룹);
+//
+//        groupAndUserRepository.saveAll(List.of(친구_그룹_연결_1, 친구_그룹_연결_2, 가족_그룹_연결, 동료_그룹_연결));
+//        groups = groupRepository.saveAll(List.of(친구_그룹, 가족_그룹, 동료_그룹));
+//
+//        testEntityManager.flush();
+//        testEntityManager.clear();
+//
+//
+//    }
+//
+//    @DisplayName("메모리를 등록하기 위해서 내가 속한 그룹 리스트를 조회한다.")
+//    @Test
+//    void 메모리_등록을_위해서_내가_속한_그룹들을_조회한다() {
+//
+//        // when
+//        List<GroupListForSaveMemoryResponseDto> userGroupListForMemoryEnroll = userGroupQueryRepository.getUserGroupListForMemoryEnroll(
+//                제민.getUserSeq());
+//
+//        // then
+//        assertThat(userGroupListForMemoryEnroll).hasSize(3);
+//        assertThat(userGroupListForMemoryEnroll).extracting("groupName")
+//                .containsExactlyInAnyOrder("친구", "가족", "동료");
+//    }
+//
+//    @DisplayName("로그인한 유저가 속해있는 그룹을 모두 조회한다.")
+//    @Test
+//    void 로그인한_유저가_속해있는_그룹을_모두_반환한다() {
+//
+//        // when
+//        List<GroupLoginUserParticipatedResponseDto> groupListLoginUserParticipate = userGroupQueryRepository.getGroupListLoginUserParticipate(
+//                제민.getUserSeq());
+//
+//        // then
+//        assertThat(groupListLoginUserParticipate).hasSize(3);
+//        assertThat(groupListLoginUserParticipate).extracting("groupName")
+//                .containsExactlyInAnyOrder("친구", "가족", "동료");
+//    }
 
 
 }

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/memory/repository/MemoryQueryRepositoryTest.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/memory/repository/MemoryQueryRepositoryTest.java
@@ -1,297 +1,264 @@
 package cmc.mellyserver.mellycore.unit.memory.repository;
 
-import cmc.mellyserver.mellycommon.enums.GroupType;
-import cmc.mellyserver.mellycommon.enums.OpenType;
-import cmc.mellyserver.mellycore.group.domain.GroupAndUser;
-import cmc.mellyserver.mellycore.group.domain.UserGroup;
-import cmc.mellyserver.mellycore.group.domain.repository.GroupAndUserRepository;
-import cmc.mellyserver.mellycore.group.domain.repository.GroupRepository;
-import cmc.mellyserver.mellycore.memory.domain.Memory;
-import cmc.mellyserver.mellycore.memory.domain.repository.MemoryQueryRepository;
-import cmc.mellyserver.mellycore.memory.domain.repository.MemoryRepository;
-import cmc.mellyserver.mellycore.memory.domain.repository.dto.FindPlaceInfoByMemoryNameResponseDto;
-import cmc.mellyserver.mellycore.memory.domain.repository.dto.MemoryResponseDto;
-import cmc.mellyserver.mellycore.memory.domain.vo.GroupInfo;
-import cmc.mellyserver.mellycore.place.domain.Place;
-import cmc.mellyserver.mellycore.place.domain.Position;
-import cmc.mellyserver.mellycore.place.domain.repository.PlaceQueryRepository;
-import cmc.mellyserver.mellycore.place.domain.repository.PlaceRepository;
 import cmc.mellyserver.mellycore.unit.RepositoryTest;
-import cmc.mellyserver.mellycore.user.domain.User;
-import cmc.mellyserver.mellycore.user.domain.repository.UserRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-
-import java.util.HashMap;
-import java.util.List;
-
-import static cmc.mellyserver.mellycore.unit.common.fixtures.UserFixtures.재현;
-import static cmc.mellyserver.mellycore.unit.common.fixtures.UserFixtures.제민;
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemoryQueryRepositoryTest extends RepositoryTest {
-
-    @Autowired
-    private MemoryQueryRepository memoryQueryRepository;
-
-    @Autowired
-    private MemoryRepository memoryRepository;
-
-    @Autowired
-    private GroupRepository groupRepository;
-
-    @Autowired
-    private GroupAndUserRepository groupAndUserRepository;
-
-    @Autowired
-    private PlaceQueryRepository placeQueryRepository;
-    @Autowired
-    private PlaceRepository placeRepository;
-
-    @Autowired
-    private UserRepository userRepository;
-
-
-    @DisplayName("장소에 포함된 메모리 제목으로 장소를 검색한다.")
-    @Test
-    void 장소에_포함된_메모리_제목으로_장소를_검색한다() {
-
-        // given
-        User 제민 = userRepository.save(제민());
-
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        Memory savedMemory = memoryRepository.save(memory);
-
-        // when
-        List<FindPlaceInfoByMemoryNameResponseDto> findPlaceInfoByMemoryNameResponseDtos = placeQueryRepository.searchPlaceByContainMemoryName(
-                제민.getUserSeq(), savedMemory.getTitle());
-
-        // then
-        Assertions.assertThat(findPlaceInfoByMemoryNameResponseDtos).hasSize(1);
-    }
-
-    @DisplayName("특정 장소에 로그인한 사용자가 작성한 메모리를 조회한다.")
-    @Test
-    void 특정_장소에_로그인한_사용자가_작성한_메모리를_조회한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        Memory savedMemory = memoryRepository.save(memory);
-        savedMemory.setKeyword(List.of("좋아요"));
-        // when
-        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryUserCreatedForPlace(
-                PageRequest.of(0, 10), 제민.getUserSeq(),
-                savedPlace.getId(), GroupType.ALL);
-
-        // then
-        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
-    }
-
-    @DisplayName("로그인한 사용자가 작성한 메모리를 조회한다.")
-    @Test
-    void 로그인한_사용자가_작성한_메모리를_모두_조회한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-        User 재현 = userRepository.save(재현());
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        memory.setKeyword(List.of("좋아요"));
-        Memory savedMemory = memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(재현.getUserSeq()).build();
-        memory2.setKeyword(List.of("좋아요"));
-        Memory savedMemory2 = memoryRepository.save(memory2);
-
-        // when
-        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryUserCreatedForMyPage(
-                PageRequest.of(0, 10), 제민.getUserSeq(),
-                GroupType.ALL);
-
-        // then
-        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
-    }
-
-    @DisplayName("로그인하지 않은 사용자가 작성한 메모리를 조회한다.")
-    @Test
-    void 로그인하지_않은_사용자가_작성한_메모리를_모두_조회한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-        User 재현 = userRepository.save(재현());
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        memory.setKeyword(List.of("좋아요"));
-        Memory savedMemory = memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(재현.getUserSeq()).build();
-        memory2.setKeyword(List.of("좋아요"));
-        Memory savedMemory2 = memoryRepository.save(memory2);
-
-        // when
-        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryOtherCreate(
-                PageRequest.of(0, 10), 재현.getUserSeq(),
-                savedPlace.getId(), GroupType.ALL);
-
-        // then
-        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
-    }
-
-    @DisplayName("로그인한 유저가 속한 그룹에서 작성한 메모리 중 전체공개와 그룹공개는 조회하고 비공개는 조회하지 않는다.")
-    @ParameterizedTest
-    @CsvSource({"ALL,2", "GROUP,2", "PRIVATE,0"})
-    void 로그인_유저가_속한_그룹에서_작성한_메모리를_모두_조회한다(OpenType openType, int memoryCount) {
-
-        // given
-        Memory memory_제민 = Memory.builder().title("테스트 메모리").userId(제민.getUserSeq())
-                .content("테스트 본문")
-                .groupInfo(new GroupInfo("친구", GroupType.FRIEND, groups.get(0).getId()))
-                .openType(openType).build();
-
-        memory_제민.setKeyword(List.of("좋아요"));
-
-        Memory memory_재현 = Memory.builder().title("테스트 메모리").userId(제민.getUserSeq())
-                .content("테스트 본문")
-                .groupInfo(new GroupInfo("친구", GroupType.FRIEND, groups.get(0).getId()))
-                .openType(openType).build();
-        memory_재현.setKeyword(List.of("좋아요"));
-
-        memoryRepository.saveAll(List.of(memory_재현, memory_제민));
-
-        // when
-        Slice<MemoryResponseDto> myGroupMemory = memoryQueryRepository.getMyGroupMemory(
-                PageRequest.of(0, 10), groups.get(0).getId(), 제민.getUserSeq());
-
-        // then
-        assertThat(myGroupMemory.getContent()).hasSize(memoryCount);
-
-    }
-
-    @DisplayName("내 그룹에 속한 사용자가 작성한 메모리를 조회한다.")
-    @Test
-    void 내그룹에_속한_사용자가_작성한_메모리를_모두_조회한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-        User 재현 = userRepository.save(재현());
-
-        UserGroup 동료_그룹 = UserGroup.builder().groupName("동료")
-                .groupType(GroupType.COMPANY).build();
-
-        groupAndUserRepository.saveAll(
-                List.of(new GroupAndUser(제민, 동료_그룹), new GroupAndUser(재현, 동료_그룹)));
-        UserGroup userGroup = groupRepository.save(동료_그룹);
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).groupInfo(
-                        new GroupInfo(userGroup.getGroupName(), userGroup.getGroupType(),
-                                userGroup.getId())).build();
-        memory.setKeyword(List.of("좋아요"));
-        Memory savedMemory = memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(재현.getUserSeq()).groupInfo(
-                        new GroupInfo(userGroup.getGroupName(), userGroup.getGroupType(),
-                                userGroup.getId())).build();
-        memory2.setKeyword(List.of("좋아요"));
-        Memory savedMemory2 = memoryRepository.save(memory2);
-
-        // when
-        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.getMyGroupMemory(
-                PageRequest.of(0, 10), 재현.getUserSeq(),
-                savedPlace.getId(), GroupType.ALL);
-
-        // then
-        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(0);
-    }
-
-    @DisplayName("특정 장소에 내가 작성한 메모리 개수를 카운트한다.")
-    @Test
-    void 특정_장소에_내가_작성한_메모리_개수를_카운트한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-        User 재현 = userRepository.save(재현());
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        memory.setKeyword(List.of("좋아요"));
-        Memory savedMemory = memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(재현.getUserSeq()).build();
-        memory2.setKeyword(List.of("좋아요"));
-        Memory savedMemory2 = memoryRepository.save(memory2);
-
-        // when
-        HashMap<String, Long> map = memoryQueryRepository.countMemoriesBelongToPlace(
-                제민.getUserSeq(), savedPlace.getId());
-
-        // then
-        Assertions.assertThat(map.get("belongToUser")).isEqualTo(1L);
-        Assertions.assertThat(map.get("notBelongToUser")).isEqualTo(1L);
-    }
-
-
-    @DisplayName("메모리 식별자를 기반으로 메모리 상세 정보를 조회한다.")
-    @Test
-    void 메모리_식별자를_기반으로_메모리_상세_정보를_조회한다() {
-
-        // given
-        Place place = Place.builder().placeName("테스트 장소")
-                .position(new Position(1.234, 1.234)).build();
-        Place savedPlace = placeRepository.save(place);
-
-        User 제민 = userRepository.save(제민());
-
-        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
-                .userId(제민.getUserSeq()).build();
-        memory.setKeyword(List.of("좋아요"));
-        Memory savedMemory = memoryRepository.save(memory);
-
-        // when
-        MemoryResponseDto memoryByMemoryId = memoryQueryRepository.getMemoryByMemoryId(
-                제민.getUserSeq(), savedMemory.getId());
-
-        // then
-        Assertions.assertThat(memoryByMemoryId.getPlaceId()).isEqualTo(savedPlace.getId());
-    }
+//
+//    @Autowired
+//    private MemoryQueryRepository memoryQueryRepository;
+//
+//    @Autowired
+//    private MemoryRepository memoryRepository;
+//
+//    @Autowired
+//    private GroupRepository groupRepository;
+//
+//    @Autowired
+//    private GroupAndUserRepository groupAndUserRepository;
+//
+//    @Autowired
+//    private PlaceQueryRepository placeQueryRepository;
+//    @Autowired
+//    private PlaceRepository placeRepository;
+//
+//    @Autowired
+//    private UserRepository userRepository;
+//
+//
+//    @DisplayName("장소에 포함된 메모리 제목으로 장소를 검색한다.")
+//    @Test
+//    void 장소에_포함된_메모리_제목으로_장소를_검색한다() {
+//
+//        // given
+//        User 제민 = userRepository.save(제민());
+//
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        // when
+//        List<FindPlaceInfoByMemoryNameResponseDto> findPlaceInfoByMemoryNameResponseDtos = placeQueryRepository.searchPlaceByContainMemoryName(
+//                제민.getUserSeq(), savedMemory.getTitle());
+//
+//        // then
+//        Assertions.assertThat(findPlaceInfoByMemoryNameResponseDtos).hasSize(1);
+//    }
+//
+//    @DisplayName("특정 장소에 로그인한 사용자가 작성한 메모리를 조회한다.")
+//    @Test
+//    void 특정_장소에_로그인한_사용자가_작성한_메모리를_조회한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        Memory savedMemory = memoryRepository.save(memory);
+//        savedMemory.setKeyword(List.of("좋아요"));
+//        // when
+//        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryUserCreatedForPlace(
+//                PageRequest.of(0, 10), 제민.getUserSeq(),
+//                savedPlace.getId(), GroupType.ALL);
+//
+//        // then
+//        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
+//    }
+//
+//    @DisplayName("로그인한 사용자가 작성한 메모리를 조회한다.")
+//    @Test
+//    void 로그인한_사용자가_작성한_메모리를_모두_조회한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//        User 재현 = userRepository.save(재현());
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        memory.setKeyword(List.of("좋아요"));
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(재현.getUserSeq()).build();
+//        memory2.setKeyword(List.of("좋아요"));
+//        Memory savedMemory2 = memoryRepository.save(memory2);
+//
+//        // when
+//        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryUserCreatedForMyPage(
+//                PageRequest.of(0, 10), 제민.getUserSeq(),
+//                GroupType.ALL);
+//
+//        // then
+//        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
+//    }
+//
+//    @DisplayName("로그인하지 않은 사용자가 작성한 메모리를 조회한다.")
+//    @Test
+//    void 로그인하지_않은_사용자가_작성한_메모리를_모두_조회한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//        User 재현 = userRepository.save(재현());
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        memory.setKeyword(List.of("좋아요"));
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(재현.getUserSeq()).build();
+//        memory2.setKeyword(List.of("좋아요"));
+//        Memory savedMemory2 = memoryRepository.save(memory2);
+//
+//        // when
+//        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.searchMemoryOtherCreate(
+//                PageRequest.of(0, 10), 재현.getUserSeq(),
+//                savedPlace.getId(), GroupType.ALL);
+//
+//        // then
+//        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(1);
+//    }
+//
+//    @DisplayName("로그인한 유저가 속한 그룹에서 작성한 메모리 중 전체공개와 그룹공개는 조회하고 비공개는 조회하지 않는다.")
+//    @ParameterizedTest
+//    @CsvSource({"ALL,2", "GROUP,2", "PRIVATE,0"})
+//    void 로그인_유저가_속한_그룹에서_작성한_메모리를_모두_조회한다(OpenType openType, int memoryCount) {
+//
+//        // given
+//        Memory memory_제민 = Memory.builder().title("테스트 메모리").userId(제민.getUserSeq())
+//                .content("테스트 본문")
+//                .groupInfo(new GroupInfo("친구", GroupType.FRIEND, groups.get(0).getId()))
+//                .openType(openType).build();
+//
+//        memory_제민.setKeyword(List.of("좋아요"));
+//
+//        Memory memory_재현 = Memory.builder().title("테스트 메모리").userId(제민.getUserSeq())
+//                .content("테스트 본문")
+//                .groupInfo(new GroupInfo("친구", GroupType.FRIEND, groups.get(0).getId()))
+//                .openType(openType).build();
+//        memory_재현.setKeyword(List.of("좋아요"));
+//
+//        memoryRepository.saveAll(List.of(memory_재현, memory_제민));
+//
+//        // when
+//        Slice<MemoryResponseDto> myGroupMemory = memoryQueryRepository.getMyGroupMemory(
+//                PageRequest.of(0, 10), groups.get(0).getId(), 제민.getUserSeq());
+//
+//        // then
+//        assertThat(myGroupMemory.getContent()).hasSize(memoryCount);
+//
+//    }
+//
+//    @DisplayName("내 그룹에 속한 사용자가 작성한 메모리를 조회한다.")
+//    @Test
+//    void 내그룹에_속한_사용자가_작성한_메모리를_모두_조회한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//        User 재현 = userRepository.save(재현());
+//
+//        UserGroup 동료_그룹 = UserGroup.builder().groupName("동료")
+//                .groupType(GroupType.COMPANY).build();
+//
+//        groupAndUserRepository.saveAll(
+//                List.of(new GroupAndUser(제민, 동료_그룹), new GroupAndUser(재현, 동료_그룹)));
+//        UserGroup userGroup = groupRepository.save(동료_그룹);
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).groupInfo(
+//                        new GroupInfo(userGroup.getGroupName(), userGroup.getGroupType(),
+//                                userGroup.getId())).build();
+//        memory.setKeyword(List.of("좋아요"));
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(재현.getUserSeq()).groupInfo(
+//                        new GroupInfo(userGroup.getGroupName(), userGroup.getGroupType(),
+//                                userGroup.getId())).build();
+//        memory2.setKeyword(List.of("좋아요"));
+//        Memory savedMemory2 = memoryRepository.save(memory2);
+//
+//        // when
+//        Slice<MemoryResponseDto> memoryResponseDtos = memoryQueryRepository.getMyGroupMemory(
+//                PageRequest.of(0, 10), 재현.getUserSeq(),
+//                savedPlace.getId(), GroupType.ALL);
+//
+//        // then
+//        Assertions.assertThat(memoryResponseDtos.getContent()).hasSize(0);
+//    }
+//
+//    @DisplayName("특정 장소에 내가 작성한 메모리 개수를 카운트한다.")
+//    @Test
+//    void 특정_장소에_내가_작성한_메모리_개수를_카운트한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//        User 재현 = userRepository.save(재현());
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        memory.setKeyword(List.of("좋아요"));
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(재현.getUserSeq()).build();
+//        memory2.setKeyword(List.of("좋아요"));
+//        Memory savedMemory2 = memoryRepository.save(memory2);
+//
+//        // when
+//        HashMap<String, Long> map = memoryQueryRepository.countMemoriesBelongToPlace(
+//                제민.getUserSeq(), savedPlace.getId());
+//
+//        // then
+//        Assertions.assertThat(map.get("belongToUser")).isEqualTo(1L);
+//        Assertions.assertThat(map.get("notBelongToUser")).isEqualTo(1L);
+//    }
+//
+//
+//    @DisplayName("메모리 식별자를 기반으로 메모리 상세 정보를 조회한다.")
+//    @Test
+//    void 메모리_식별자를_기반으로_메모리_상세_정보를_조회한다() {
+//
+//        // given
+//        Place place = Place.builder().placeName("테스트 장소")
+//                .position(new Position(1.234, 1.234)).build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        User 제민 = userRepository.save(제민());
+//
+//        Memory memory = Memory.builder().title("테스트 제목").placeId(savedPlace.getId())
+//                .userId(제민.getUserSeq()).build();
+//        memory.setKeyword(List.of("좋아요"));
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        // when
+//        MemoryResponseDto memoryByMemoryId = memoryQueryRepository.getMemoryByMemoryId(
+//                제민.getUserSeq(), savedMemory.getId());
+//
+//        // then
+//        Assertions.assertThat(memoryByMemoryId.getPlaceId()).isEqualTo(savedPlace.getId());
+//    }
 }

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/place/repository/PlaceQueryRepositoryTest.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/place/repository/PlaceQueryRepositoryTest.java
@@ -1,190 +1,166 @@
 package cmc.mellyserver.mellycore.unit.place.repository;
 
-import cmc.mellyserver.mellycommon.enums.Provider;
-import cmc.mellyserver.mellycommon.enums.ScrapType;
-import cmc.mellyserver.mellycore.memory.domain.Memory;
-import cmc.mellyserver.mellycore.memory.domain.repository.MemoryRepository;
-import cmc.mellyserver.mellycore.place.domain.Place;
-import cmc.mellyserver.mellycore.place.domain.Position;
-import cmc.mellyserver.mellycore.place.domain.repository.PlaceQueryRepository;
-import cmc.mellyserver.mellycore.place.domain.repository.PlaceRepository;
-import cmc.mellyserver.mellycore.scrap.domain.PlaceScrap;
-import cmc.mellyserver.mellycore.scrap.domain.repository.PlaceScrapRepository;
-import cmc.mellyserver.mellycore.scrap.domain.repository.dto.PlaceScrapCountResponseDto;
-import cmc.mellyserver.mellycore.scrap.domain.repository.dto.ScrapedPlaceResponseDto;
 import cmc.mellyserver.mellycore.unit.RepositoryTest;
-import cmc.mellyserver.mellycore.user.domain.User;
-import cmc.mellyserver.mellycore.user.domain.repository.UserRepository;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Slice;
-
-import java.util.List;
 
 public class PlaceQueryRepositoryTest extends RepositoryTest {
 
 
-    @Autowired
-    private PlaceQueryRepository placeQueryRepository;
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private PlaceRepository placeRepository;
-
-    @Autowired
-    private MemoryRepository memoryRepository;
-
-    @Autowired
-    private PlaceScrapRepository placeScrapRepository;
-    ;
-
-
-    @DisplayName("사용자가 작성한 메모리가 존재하는 장소 리스트를 받아온다.")
-    @Test
-    void get_place_login_user_made_memory() {
-
-        // given
-        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
-        User otherUser = User.builder().nickname("테스트 유저2").provider(Provider.DEFAULT).build();
-        User savedUser = userRepository.save(user);
-        User savedOtherUser = userRepository.save(otherUser);
-
-        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
-                .build();
-        Place savedPlace = placeRepository.save(place);
-
-        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
-                .build();
-        Place savedPlace2 = placeRepository.save(place2);
-
-        Memory memory = Memory.builder().userId(savedUser.getUserSeq()).placeId(savedPlace.getId())
-                .title("테스트 메모리").build();
-
-        Memory savedMemory = memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().userId(savedOtherUser.getUserSeq())
-                .placeId(savedPlace2.getId())
-                .title("테스트 메모리2").build();
-
-        Memory savedMemory2 = memoryRepository.save(memory2);
-
-        // when
-        List<Place> placeUserMemoryExist = placeQueryRepository.getPlaceUserMemoryExist(
-                user.getUserSeq());
-
-        // then
-        Assertions.assertThat(placeUserMemoryExist).hasSize(1);
-        Assertions.assertThat(placeUserMemoryExist)
-                .extracting("placeName")
-                .containsExactlyInAnyOrder("테스트 장소");
-    }
-
-    @DisplayName("로그인한 사용자가 스크랩한 장소 개수를 타입별로 조회할 수 있다.")
-    @Test
-    void get_place_count_login_user_write() {
-
-        // given
-        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
-        User savedUser = userRepository.save(user);
-
-        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
-                .build();
-        Place savedPlace = placeRepository.save(place);
-
-        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
-                .build();
-        Place savedPlace2 = placeRepository.save(place2);
-
-        Place place3 = Place.builder().position(new Position(1.236, 1.236)).placeName("테스트 장소3")
-                .build();
-        Place savedPlace3 = placeRepository.save(place3);
-
-        Place place4 = Place.builder().position(new Position(1.237, 1.237)).placeName("테스트 장소4")
-                .build();
-        Place savedPlace4 = placeRepository.save(place4);
-
-        PlaceScrap scrap = PlaceScrap.createScrap(savedUser, savedPlace, ScrapType.FRIEND);
-
-        PlaceScrap scrap1 = PlaceScrap.createScrap(savedUser, savedPlace2, ScrapType.FRIEND);
-
-        PlaceScrap scrap2 = PlaceScrap.createScrap(savedUser, savedPlace3, ScrapType.COMPANY);
-
-        PlaceScrap scrap3 = PlaceScrap.createScrap(savedUser, savedPlace4, ScrapType.COUPLE);
-
-        placeScrapRepository.saveAll(List.of(scrap, scrap1, scrap2, scrap3));
-
-        // when
-        List<PlaceScrapCountResponseDto> scrapedPlaceGrouping = placeQueryRepository.getScrapedPlaceGrouping(
-                savedUser);
-
-        // then
-        Assertions.assertThat(scrapedPlaceGrouping).hasSize(3);
-        Assertions.assertThat(scrapedPlaceGrouping).extracting("scrapCount")
-                .containsExactlyInAnyOrder(1L, 1L, 2L);
-    }
-
-    @DisplayName("스크랩한 장소 리스트를 스크랩 타입별로 가져온다.")
-    @ParameterizedTest
-    @CsvSource(value = {"FRIEND,2", "COMPANY,1", "COUPLE,1", "ALL,4"})
-    void get_scraped_place_list(ScrapType scrapType, int expected) {
-
-        // given
-        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
-        User otherUser = User.builder().nickname("테스트 유저2").provider(Provider.DEFAULT).build();
-        User savedUser = userRepository.save(user);
-        User savedOtherUser = userRepository.save(otherUser);
-
-        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
-                .build();
-        Place savedPlace = placeRepository.save(place);
-
-        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
-                .build();
-        Place savedPlace2 = placeRepository.save(place2);
-
-        Place place3 = Place.builder().position(new Position(1.236, 1.236)).placeName("테스트 장소3")
-                .build();
-        Place savedPlace3 = placeRepository.save(place3);
-
-        Place place4 = Place.builder().position(new Position(1.237, 1.237)).placeName("테스트 장소4")
-                .build();
-        Place savedPlace4 = placeRepository.save(place4);
-
-        Memory memory = Memory.builder().userId(savedUser.getUserSeq()).placeId(savedPlace.getId())
-                .title("테스트 메모리").build();
-
-        memoryRepository.save(memory);
-
-        Memory memory2 = Memory.builder().userId(savedOtherUser.getUserSeq())
-                .placeId(savedPlace.getId())
-                .title("테스트 메모리").build();
-
-        memoryRepository.save(memory2);
-
-        PlaceScrap scrap = PlaceScrap.createScrap(savedUser, savedPlace, ScrapType.FRIEND);
-
-        PlaceScrap scrap1 = PlaceScrap.createScrap(savedUser, savedPlace2, ScrapType.FRIEND);
-
-        PlaceScrap scrap2 = PlaceScrap.createScrap(savedUser, savedPlace3, ScrapType.COMPANY);
-
-        PlaceScrap scrap3 = PlaceScrap.createScrap(savedUser, savedPlace4, ScrapType.COUPLE);
-
-        placeScrapRepository.saveAll(List.of(scrap, scrap1, scrap2, scrap3));
-
-        // when
-        Slice<ScrapedPlaceResponseDto> scrapedPlace = placeQueryRepository.getScrapedPlace(
-                PageRequest.of(0, 10),
-                user.getUserSeq(), scrapType);
-
-        // then
-        Assertions.assertThat(scrapedPlace.getContent()).hasSize(expected);
-
-    }
+//    @Autowired
+//    private PlaceQueryRepository placeQueryRepository;
+//
+//    @Autowired
+//    private UserRepository userRepository;
+//
+//    @Autowired
+//    private PlaceRepository placeRepository;
+//
+//    @Autowired
+//    private MemoryRepository memoryRepository;
+//
+//    @Autowired
+//    private PlaceScrapRepository placeScrapRepository;
+//    ;
+//
+//
+//    @DisplayName("사용자가 작성한 메모리가 존재하는 장소 리스트를 받아온다.")
+//    @Test
+//    void get_place_login_user_made_memory() {
+//
+//        // given
+//        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
+//        User otherUser = User.builder().nickname("테스트 유저2").provider(Provider.DEFAULT).build();
+//        User savedUser = userRepository.save(user);
+//        User savedOtherUser = userRepository.save(otherUser);
+//
+//        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
+//                .build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
+//                .build();
+//        Place savedPlace2 = placeRepository.save(place2);
+//
+//        Memory memory = Memory.builder().userId(savedUser.getUserSeq()).placeId(savedPlace.getId())
+//                .title("테스트 메모리").build();
+//
+//        Memory savedMemory = memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().userId(savedOtherUser.getUserSeq())
+//                .placeId(savedPlace2.getId())
+//                .title("테스트 메모리2").build();
+//
+//        Memory savedMemory2 = memoryRepository.save(memory2);
+//
+//        // when
+//        List<Place> placeUserMemoryExist = placeQueryRepository.getPlaceUserMemoryExist(
+//                user.getUserSeq());
+//
+//        // then
+//        Assertions.assertThat(placeUserMemoryExist).hasSize(1);
+//        Assertions.assertThat(placeUserMemoryExist)
+//                .extracting("placeName")
+//                .containsExactlyInAnyOrder("테스트 장소");
+//    }
+//
+//    @DisplayName("로그인한 사용자가 스크랩한 장소 개수를 타입별로 조회할 수 있다.")
+//    @Test
+//    void get_place_count_login_user_write() {
+//
+//        // given
+//        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
+//        User savedUser = userRepository.save(user);
+//
+//        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
+//                .build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
+//                .build();
+//        Place savedPlace2 = placeRepository.save(place2);
+//
+//        Place place3 = Place.builder().position(new Position(1.236, 1.236)).placeName("테스트 장소3")
+//                .build();
+//        Place savedPlace3 = placeRepository.save(place3);
+//
+//        Place place4 = Place.builder().position(new Position(1.237, 1.237)).placeName("테스트 장소4")
+//                .build();
+//        Place savedPlace4 = placeRepository.save(place4);
+//
+//        PlaceScrap scrap = PlaceScrap.createScrap(savedUser, savedPlace, ScrapType.FRIEND);
+//
+//        PlaceScrap scrap1 = PlaceScrap.createScrap(savedUser, savedPlace2, ScrapType.FRIEND);
+//
+//        PlaceScrap scrap2 = PlaceScrap.createScrap(savedUser, savedPlace3, ScrapType.COMPANY);
+//
+//        PlaceScrap scrap3 = PlaceScrap.createScrap(savedUser, savedPlace4, ScrapType.COUPLE);
+//
+//        placeScrapRepository.saveAll(List.of(scrap, scrap1, scrap2, scrap3));
+//
+//        // when
+//        List<PlaceScrapCountResponseDto> scrapedPlaceGrouping = placeQueryRepository.getScrapedPlaceGrouping(
+//                savedUser);
+//
+//        // then
+//        Assertions.assertThat(scrapedPlaceGrouping).hasSize(3);
+//        Assertions.assertThat(scrapedPlaceGrouping).extracting("scrapCount")
+//                .containsExactlyInAnyOrder(1L, 1L, 2L);
+//    }
+//
+//    @DisplayName("스크랩한 장소 리스트를 스크랩 타입별로 가져온다.")
+//    @ParameterizedTest
+//    @CsvSource(value = {"FRIEND,2", "COMPANY,1", "COUPLE,1", "ALL,4"})
+//    void get_scraped_place_list(ScrapType scrapType, int expected) {
+//
+//        // given
+//        User user = User.builder().nickname("테스트 유저").provider(Provider.DEFAULT).build();
+//        User otherUser = User.builder().nickname("테스트 유저2").provider(Provider.DEFAULT).build();
+//        User savedUser = userRepository.save(user);
+//        User savedOtherUser = userRepository.save(otherUser);
+//
+//        Place place = Place.builder().position(new Position(1.234, 1.234)).placeName("테스트 장소")
+//                .build();
+//        Place savedPlace = placeRepository.save(place);
+//
+//        Place place2 = Place.builder().position(new Position(1.235, 1.235)).placeName("테스트 장소2")
+//                .build();
+//        Place savedPlace2 = placeRepository.save(place2);
+//
+//        Place place3 = Place.builder().position(new Position(1.236, 1.236)).placeName("테스트 장소3")
+//                .build();
+//        Place savedPlace3 = placeRepository.save(place3);
+//
+//        Place place4 = Place.builder().position(new Position(1.237, 1.237)).placeName("테스트 장소4")
+//                .build();
+//        Place savedPlace4 = placeRepository.save(place4);
+//
+//        Memory memory = Memory.builder().userId(savedUser.getUserSeq()).placeId(savedPlace.getId())
+//                .title("테스트 메모리").build();
+//
+//        memoryRepository.save(memory);
+//
+//        Memory memory2 = Memory.builder().userId(savedOtherUser.getUserSeq())
+//                .placeId(savedPlace.getId())
+//                .title("테스트 메모리").build();
+//
+//        memoryRepository.save(memory2);
+//
+//        PlaceScrap scrap = PlaceScrap.createScrap(savedUser, savedPlace, ScrapType.FRIEND);
+//
+//        PlaceScrap scrap1 = PlaceScrap.createScrap(savedUser, savedPlace2, ScrapType.FRIEND);
+//
+//        PlaceScrap scrap2 = PlaceScrap.createScrap(savedUser, savedPlace3, ScrapType.COMPANY);
+//
+//        PlaceScrap scrap3 = PlaceScrap.createScrap(savedUser, savedPlace4, ScrapType.COUPLE);
+//
+//        placeScrapRepository.saveAll(List.of(scrap, scrap1, scrap2, scrap3));
+//
+//        // when
+//        Slice<ScrapedPlaceResponseDto> scrapedPlace = placeQueryRepository.getScrapedPlace(
+//                PageRequest.of(0, 10),
+//                user.getUserSeq(), scrapType);
+//
+//        // then
+//        Assertions.assertThat(scrapedPlace.getContent()).hasSize(expected);
+//
+//    }
 }

--- a/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/scrap/repository/BulkInsertTest.java
+++ b/melly-core/src/test/java/cmc/mellyserver/mellycore/unit/scrap/repository/BulkInsertTest.java
@@ -1,14 +1,14 @@
 package cmc.mellyserver.mellycore.unit.scrap.repository;
 
-import cmc.mellyserver.mellycommon.enums.DeleteStatus;
-import cmc.mellyserver.mellycore.place.domain.Place;
-import cmc.mellyserver.mellycore.scrap.domain.PlaceScrap;
+import cmc.mellyserver.mellycore.memory.domain.Memory;
 import cmc.mellyserver.mellycore.scrap.domain.repository.PlaceScrapJDBCRepository;
 import cmc.mellyserver.mellycore.scrap.domain.repository.PlaceScrapRepository;
 import cmc.mellyserver.mellycore.unit.common.fixtures.PlaceScrapFixtureFactory;
+import cmc.mellyserver.mellycore.user.domain.User;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,86 +25,26 @@ import java.util.stream.IntStream;
 @Rollback(value = false)
 public class BulkInsertTest {
 
+    @TestConfiguration
+    static class Config {
+
+    }
+
     @Autowired
     public PlaceScrapRepository placeScrapRepository;
 
     @Autowired
     public PlaceScrapJDBCRepository placeScrapJDBCRepository;
 
-//    @Autowired
-//    public NamedParameterJdbcTemplate namedParameterJdbcTemplate;
-
-    static final String TABLE = "tb_place_scrap";
-
-    //        List<PlaceScrap> collect = IntStream.range(0, _1만 * 1)
-//                .parallel() // 병렬로 안 돌리면 시간 완전 오래 걸린다.
-//                .mapToObj(i -> easyRandom.nextObject(PlaceScrap.class))
-//                .collect(Collectors.toList());
-
-    @Test
-    public void bulkInsert() {
-//        var easyRandom = PlaceScrapFixtureFactory.get(1L, 2L);
-
-        var stopWatch = new StopWatch();
-        stopWatch.start(); // 시간 재기
-
-        int _300만 = 3_000_000;
-
-
-        List<Place> places = IntStream.range(0, _300만)
-                .parallel()
-                .mapToObj(i -> Place.builder().placeName("장소").isDeleted(DeleteStatus.N).build())
-                .collect(Collectors.toList());
-
-        stopWatch.stop();
-        System.out.println("객체 생성 시간 : " + stopWatch.getTotalTimeSeconds());
-
-        var queryStopWatch = new StopWatch();
-        queryStopWatch.start();
-
-        placeScrapJDBCRepository.saveAll(places);
-
-        queryStopWatch.stop();
-        System.out.println("DB 인서트 시간 : " + queryStopWatch.getTotalTimeSeconds());
-    }
-
-    @Test
-    public void bulkInsert_place_scrap() {
-
-        var easyRandom = PlaceScrapFixtureFactory.get();
-        int _10만 = 1_000_000;
-
-        List<PlaceScrap> collect = IntStream.range(0, _10만 * 1)
-                .parallel() // 병렬로 안 돌리면 시간 완전 오래 걸린다.
-                .mapToObj(i -> easyRandom.nextObject(PlaceScrap.class))
-                .collect(Collectors.toList());
-
-        var stopWatch = new StopWatch();
-
-        stopWatch.start(); // 시간 재기
-
-
-        stopWatch.stop();
-        System.out.println("객체 생성 시간 : " + stopWatch.getTotalTimeSeconds());
-
-        var queryStopWatch = new StopWatch();
-        queryStopWatch.start();
-
-        placeScrapJDBCRepository.savePlaceScrap(collect);
-
-        queryStopWatch.stop();
-        System.out.println("DB 인서트 시간 : " + queryStopWatch.getTotalTimeSeconds());
-    }
-
     @Test
     public void bulkInsert_user() {
 
-        var easyRandom = PlaceScrapFixtureFactory.get();
-        int _10만 = 1_000_000;
+        var easyRandom = PlaceScrapFixtureFactory.createUser("$2a$10$rghaTRzFA74TXU.qDeTySOwqXo6ckpvtCKWbsba8W7hlc6HIYbKIu");
+        int _10만 = 2_000_000;
 
-        List<PlaceScrap> collect = IntStream.range(0, _10만 * 1)
+        List<User> users = IntStream.range(0, _10만 * 1)
                 .parallel() // 병렬로 안 돌리면 시간 완전 오래 걸린다.
-                .mapToObj(i -> easyRandom.nextObject(PlaceScrap.class))
+                .mapToObj(i -> easyRandom.nextObject(User.class))
                 .collect(Collectors.toList());
 
         var stopWatch = new StopWatch();
@@ -118,23 +58,39 @@ public class BulkInsertTest {
         var queryStopWatch = new StopWatch();
         queryStopWatch.start();
 
-        placeScrapJDBCRepository.savePlaceScrap(collect);
+        placeScrapJDBCRepository.saveUser(users);
+
+        queryStopWatch.stop();
+        System.out.println("DB 인서트 시간 : " + queryStopWatch.getTotalTimeSeconds());
+    }
+
+    @Test
+    public void bulkInsert_memory() {
+
+        var easyRandom = PlaceScrapFixtureFactory.createUser("$2a$10$rghaTRzFA74TXU.qDeTySOwqXo6ckpvtCKWbsba8W7hlc6HIYbKIu");
+        int _10만 = 3_000_000;
+
+        List<Memory> users = IntStream.range(0, _10만 * 1)
+                .parallel() // 병렬로 안 돌리면 시간 완전 오래 걸린다.
+                .mapToObj(i -> easyRandom.nextObject(Memory.class))
+                .collect(Collectors.toList());
+
+        var stopWatch = new StopWatch();
+
+        stopWatch.start(); // 시간 재기
+
+
+        stopWatch.stop();
+        System.out.println("객체 생성 시간 : " + stopWatch.getTotalTimeSeconds());
+
+        var queryStopWatch = new StopWatch();
+        queryStopWatch.start();
+
+        placeScrapJDBCRepository.saveUser(users);
 
         queryStopWatch.stop();
         System.out.println("DB 인서트 시간 : " + queryStopWatch.getTotalTimeSeconds());
     }
 
 
-//    public void bulkInsert(List<PlaceScrap> placeScrap) {
-//        var sql = String.format("INSERT INTO `%s` (scrap_type)" +
-//                "VALUES (:scrapType)", TABLE);
-//
-//        List<String> collect = placeScrap.stream().map(t -> t.getScrapType().toString()).collect(Collectors.toList());
-//
-//        SqlParameterSource[] collects = collect
-//                .stream()
-//                .map(BeanPropertySqlParameterSource::new)
-//                .toArray(SqlParameterSource[]::new);
-//        namedParameterJdbcTemplate.batchUpdate(sql, collects);
-//    }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/alarm/FCMSender.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/alarm/FCMSender.java
@@ -17,19 +17,21 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.IOException;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class FCMSender {
 
     private static final String API_URL = "https://fcm.googleapis.com/v1/projects/melly-fdd90/messages:send";
+
     private final NotificationService notificationService;
+
     private final ObjectMapper objectMapper;
 
     private String getAccessToken() throws IOException {
+
         String firebaseConfigPath = "firebase/melly-fdd90-firebase-adminsdk-a139l-bd9a957ecb.json";
-        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(
-                        new ClassPathResource(firebaseConfigPath).getInputStream())
+        GoogleCredentials googleCredentials = GoogleCredentials.fromStream(new ClassPathResource(firebaseConfigPath).getInputStream())
                 .createScoped(List.of("https://www.googleapis.com/auth/cloud-platform"));
 
         googleCredentials.refreshIfExpired();
@@ -37,8 +39,7 @@ public class FCMSender {
     }
 
     @Transactional
-    public void sendMessageTo(String targetToken, NotificationType notificationType, String body, Long userSeq,
-                              Long memoryId) throws IOException {
+    public void sendMessageTo(String targetToken, NotificationType notificationType, String body, Long userSeq, Long memoryId) throws IOException {
 
         notificationService.createNotification(notificationType, body, userSeq, memoryId);
         String message = makeMessage(targetToken, notificationType, body);
@@ -53,17 +54,17 @@ public class FCMSender {
 
         Response response = okHttpClient.newCall(request).execute();
         log.info(response.body().string());
-
     }
 
-    private String makeMessage(String targetToken, NotificationType notificationType, String body) throws
-            JsonProcessingException {
+    private String makeMessage(String targetToken, NotificationType notificationType, String body) throws JsonProcessingException {
+
         FCMMessage fcmMessage = FCMMessage.builder()
                 .message(FCMMessage.Message.builder()
                         .token(targetToken)
-                        .notification(FCMMessage.Notification.builder()
-                                .title(notificationType).body(body).image(null).build()
-                        ).build()).validateOnly(false).build();
+                        .notification(FCMMessage.Notification.builder().title(notificationType).body(body).image(null).build())
+                        .build())
+                .validateOnly(false).build();
+
         return objectMapper.writeValueAsString(fcmMessage);
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/AWSS3UploadService.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/AWSS3UploadService.java
@@ -17,12 +17,13 @@ import java.io.InputStream;
 public class AWSS3UploadService {
 
     private final AmazonS3 amazonS3;
+
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
     public void uploadFile(InputStream inputStream, ObjectMetadata objectMetadata, String filename) {
-        amazonS3.putObject(new PutObjectRequest(bucket, filename, inputStream, objectMetadata).withCannedAcl(
-                CannedAccessControlList.PublicRead));
+
+        amazonS3.putObject(new PutObjectRequest(bucket, filename, inputStream, objectMetadata).withCannedAcl(CannedAccessControlList.PublicRead));
     }
 
     public String getFileUrl(String filename) {

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/AwsServiceImpl.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/AwsServiceImpl.java
@@ -10,17 +10,19 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
+@Profile({"local", "prod"})
 @Component
 @RequiredArgsConstructor
-@Profile({"local", "prod"})
 public class AwsServiceImpl implements AwsService {
 
     private final AmazonS3Client amazonS3Client;
 
     @Override
     public Long calculateImageVolume(String bucketName, String username) {
+
         ObjectListing mellyimage = amazonS3Client.listObjects(bucketName, username);
         List<S3ObjectSummary> objectSummaries = mellyimage.getObjectSummaries();
+
         return objectSummaries.stream().mapToLong(S3ObjectSummary::getSize).sum();
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/S3FileLoader.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/S3FileLoader.java
@@ -13,9 +13,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+@Profile({"local", "prod"})
 @Component
 @RequiredArgsConstructor
-@Profile({"local", "prod"})
 public class S3FileLoader implements FileUploader {
 
     private final AWSS3UploadService uploadService;
@@ -67,20 +67,21 @@ public class S3FileLoader implements FileUploader {
     }
 
     private String createFileNames(String uid, String fileName) {
+
         return uid + "/" + UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }
 
     private String createFileName(String fileName) {
+
         return "profile/" + UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }
 
-    // file 형식이 잘못된 경우를 확인하기 위해 만들어진 로직이며, 파일 타입과 상관없이 업로드할 수 있게 하기 위해 .의 존재 유무만 판단하였습니다.
     private String getFileExtension(String fileName) {
+
         try {
             return fileName.substring(fileName.lastIndexOf("."));
         } catch (StringIndexOutOfBoundsException e) {
             throw new IllegalArgumentException("잘못된 형식 입니다.");
         }
     }
-
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/config/AwsConfig.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/config/AwsConfig.java
@@ -1,6 +1,5 @@
 package cmc.mellyserver.mellyinfra.aws.config;
 
-
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3Client;
@@ -10,8 +9,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
-@Configuration
 @Profile({"local", "prod"})
+@Configuration
 public class AwsConfig {
 
     @Value("${cloud.aws.credentials.access-key}")
@@ -25,10 +24,10 @@ public class AwsConfig {
 
     @Bean
     public AmazonS3Client amazonS3Client() {
+
         BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
         return (AmazonS3Client) AmazonS3ClientBuilder.standard()
                 .withRegion(region)
-                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
-                .build();
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds)).build();
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/AppleClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/AppleClient.java
@@ -55,7 +55,6 @@ public class AppleClient implements LoginClient {
                 .block();
 
         try {
-
             String headerOfIdentityToken = accessToken.substring(0, accessToken.indexOf("."));
 
             Map<String, String> header = new ObjectMapper().readValue(
@@ -103,7 +102,5 @@ public class AppleClient implements LoginClient {
         }
 
         return null;
-
     }
-
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/GoogleClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/GoogleClient.java
@@ -43,6 +43,5 @@ public class GoogleClient implements LoginClient {
                 .provider(Provider.GOOGLE)
                 .password("NO_PASSWORD")
                 .roleType(RoleType.USER).build();
-
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/LoginClientFactory.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/LoginClientFactory.java
@@ -14,6 +14,7 @@ import java.util.Map;
 public class LoginClientFactory {
 
     private final List<LoginClient> loginClientList;
+
     private final Map<Provider, LoginClient> factoryCache = new HashMap<>();
 
     public LoginClient find(Provider provider) {
@@ -28,7 +29,6 @@ public class LoginClientFactory {
                 .orElseThrow();
 
         factoryCache.put(provider, loginClient);
-
         return loginClient;
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/WebClientConfig.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/WebClientConfig.java
@@ -16,8 +16,8 @@ import reactor.netty.tcp.TcpClient;
 
 import java.util.concurrent.TimeUnit;
 
-@Configuration
 @Slf4j
+@Configuration
 public class WebClientConfig {
 
     @Bean

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/AppleUserData.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/AppleUserData.java
@@ -12,6 +12,7 @@ public class AppleUserData {
     private List<Key> keys;
 
     public Optional<Key> getMatchedKeyBy(String kid, String alg) {
+
         return this.keys.stream()
                 .filter(key -> key.getKid().equals(kid) && key.getAlg().equals(alg))
                 .findFirst();
@@ -22,10 +23,15 @@ public class AppleUserData {
     public static class Key {
 
         private String kty;
+
         private String kid;
+
         private String use;
+
         private String alg;
+
         private String n;
+
         private String e;
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/GoogleUserData.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/GoogleUserData.java
@@ -11,7 +11,9 @@ import lombok.NoArgsConstructor;
 public class GoogleUserData {
 
     private String sub;
+
     private String email;
+
     private Boolean email_verified;
 
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/NaverUserData.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/NaverUserData.java
@@ -10,7 +10,9 @@ import lombok.NoArgsConstructor;
 public class NaverUserData {
 
     private String resultcode;
+
     private String message;
+
     private Response response;
 
     @Data
@@ -18,8 +20,9 @@ public class NaverUserData {
     public class Response {
 
         private String id;
-        private String email;
-        private String nickname;
 
+        private String email;
+
+        private String nickname;
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/key/Key.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/key/Key.java
@@ -3,10 +3,15 @@ package cmc.mellyserver.mellyinfra.client.key;
 public class Key {
 
     private String kty;
+
     private String kid;
+
     private String use;
+
     private String alg;
+
     private String n;
+
     private String e;
 
     public String getKty() {
@@ -56,5 +61,4 @@ public class Key {
     public void setE(String e) {
         this.e = e;
     }
-
 }


### PR DESCRIPTION
## 💡 수정 내용
- 스크랩 도메인에 Left Outer Join으로 조인이 적용되어 있던 쿼리들 inner Join + fetch Join으로 수정

## 💡 고려 사항
- 스크랩 도메인 쿼리 수정 중, 연관 관계가 맺어져 있는 Place 도메인과 User 도메인의 식별자만 계속 필요하다는 걸 발견. 기존의 연관 관계가 맺어져 있는 상황에서 인덱스를 걸었을때 데이터 조회 속도와 User 식별자와 Place 식별자만 Scrap에 저장했을때의 조회 속도를 비교 후, 현저한 차이가 날 경우 최종 변경 예정