### PR TITLE
[Feature/#79] Refresh Token 연장 방식을 변경한다

### DIFF
--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/OAuthService.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/OAuthService.java
@@ -1,15 +1,27 @@
 package cmc.mellyserver.mellyapi.auth.application;
 
 import cmc.mellyserver.mellyapi.auth.application.dto.request.OAuthLoginRequestDto;
+import cmc.mellyserver.mellyapi.auth.application.dto.response.RefreshTokenDto;
+import cmc.mellyserver.mellyapi.auth.application.dto.response.TokenResponseDto;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.request.OAuthSignupRequestDto;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.response.OAuthResponseDto;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.response.OAuthSignupResponseDto;
+import cmc.mellyserver.mellyapi.auth.repository.RefreshToken;
+import cmc.mellyserver.mellyapi.auth.repository.RefreshTokenRepository;
 import cmc.mellyserver.mellyapi.common.token.JwtTokenProvider;
+import cmc.mellyserver.mellycore.comment.application.event.SignupEvent;
 import cmc.mellyserver.mellycore.user.domain.User;
 import cmc.mellyserver.mellycore.user.domain.repository.UserRepository;
 import cmc.mellyserver.mellyinfra.client.LoginClient;
 import cmc.mellyserver.mellyinfra.client.LoginClientFactory;
+import cmc.mellyserver.mellyinfra.message.FCMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
 
 @Slf4j
 @Service
@@ -22,23 +34,60 @@ public class OAuthService {
 
     private final JwtTokenProvider tokenProvider;
 
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final FCMService fcmService;
+
+    private final ApplicationEventPublisher publisher;
+
     @Transactional
-    public String login(OAuthLoginRequestDto oAuthLoginRequestDto) {
+    public OAuthResponseDto login(OAuthLoginRequestDto oAuthLoginRequestDto) {
 
-        LoginClient loginClient = loginClientFactory.find(oAuthLoginRequestDto.getProvider()); // provider에 맞는 로그인 클라이언트 가져오기
-        User socialUser = loginClient.getUserData(oAuthLoginRequestDto.getAccessToken()); // 유저 정보 받아오기
+        LoginClient loginClient = loginClientFactory.find(oAuthLoginRequestDto.getProvider());
+        User socialUser = loginClient.getUserData(oAuthLoginRequestDto.getAccessToken());
 
-        User user = userRepository.findUserBySocialId(socialUser.getSocialId()); // 기존에 존재하는 유저가 있는지 찾는다.
+        // socialId를 이용해서 기존에 회원가입한 회원인지 체크한다.
+        // 이메일의 경우, KAKAO는 비즈앱에 심사 거쳐야만 이메일을 필수로 받을 수 있다. 따라서 이메일이 무조건 있다는 보장 없음
+        User user = userRepository.findUserBySocialId(socialUser.getSocialId());
 
-//        if (Objects.isNull(user)) { // 만약에 기존에 존재하는 유저가 없다면
-//            User savedUser = userRepository.save(socialUser); // 새로 만든 유저를 저장한다.
-//            return tokenProvider.createToken(savedUser.getId(), savedUser.getRoleType());
-//        }
-//
-//        user.updateSocialLoginInfo(socialUser.getSocialId(), socialUser.getProvider());
-//        return tokenProvider.createToken(user.getId(), user.getRoleType());
-        return null;
+        // 만약
+        if (Objects.isNull(user)) {
+
+            return new OAuthResponseDto(null, new OAuthSignupResponseDto(socialUser.getEmail(), socialUser.getSocialId(), socialUser.getProvider()));
+        }
+
+        user.updateOauthInfo(socialUser.getNickname(), socialUser.getSocialId());
+
+        String accessToken = tokenProvider.createAccessToken(user.getId(), user.getRoleType());
+        RefreshTokenDto refreshToken = tokenProvider.createRefreshToken(user.getId(), user.getRoleType());
+
+        //레디스에 저장 Refresh 토큰을 저장한다. (사용자 Id, refresh 토큰)
+        refreshTokenRepository.save(new RefreshToken(refreshToken.getToken(), user.getId()), refreshToken.getExpiredAt());
+
+        // 사용자 FCM 토큰을 Redis에 저장한다. -> 이벤트 처리 생각중
+        fcmService.saveToken(user.getId(), oAuthLoginRequestDto.getFcmToken());
+
+        return new OAuthResponseDto(TokenResponseDto.of(accessToken, refreshToken.getToken()), null);
     }
 
 
+    public TokenResponseDto signup(OAuthSignupRequestDto oAuthSignupRequestDto) {
+
+        User oauthLoginUser = User.createOauthLoginUser(oAuthSignupRequestDto.getSocialId(), oAuthSignupRequestDto.getProvider(), oAuthSignupRequestDto.getEmail(), oAuthSignupRequestDto.getNickname(), oAuthSignupRequestDto.getAgeGroup(), oAuthSignupRequestDto.getGender());
+        User user = userRepository.save(oauthLoginUser);
+
+        String accessToken = tokenProvider.createAccessToken(user.getId(), user.getRoleType());
+        RefreshTokenDto refreshToken = tokenProvider.createRefreshToken(user.getId(), user.getRoleType());
+
+        //레디스에 저장 Refresh 토큰을 저장한다. (사용자 Id, refresh 토큰)
+        refreshTokenRepository.save(new RefreshToken(refreshToken.getToken(), user.getId()), refreshToken.getExpiredAt());
+
+        // 사용자 FCM 토큰을 Redis에 저장한다. -> 이벤트 처리 생각중
+        fcmService.saveToken(user.getId(), oAuthSignupRequestDto.getFcmToken());
+
+        if (Objects.nonNull(user.getEmail())) {
+            publisher.publishEvent(new SignupEvent(user.getId()));
+        }
+        return TokenResponseDto.of(accessToken, refreshToken.getToken());
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/OAuthService.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/OAuthService.java
@@ -11,8 +11,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -32,13 +30,14 @@ public class OAuthService {
 
         User user = userRepository.findUserBySocialId(socialUser.getSocialId()); // 기존에 존재하는 유저가 있는지 찾는다.
 
-        if (Objects.isNull(user)) { // 만약에 기존에 존재하는 유저가 없다면
-            User savedUser = userRepository.save(socialUser); // 새로 만든 유저를 저장한다.
-            return tokenProvider.createToken(savedUser.getId(), savedUser.getRoleType());
-        }
-
-        user.updateSocialLoginInfo(socialUser.getSocialId(), socialUser.getProvider());
-        return tokenProvider.createToken(user.getId(), user.getRoleType());
+//        if (Objects.isNull(user)) { // 만약에 기존에 존재하는 유저가 없다면
+//            User savedUser = userRepository.save(socialUser); // 새로 만든 유저를 저장한다.
+//            return tokenProvider.createToken(savedUser.getId(), savedUser.getRoleType());
+//        }
+//
+//        user.updateSocialLoginInfo(socialUser.getSocialId(), socialUser.getProvider());
+//        return tokenProvider.createToken(user.getId(), user.getRoleType());
+        return null;
     }
 
 

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/dto/response/RefreshTokenDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/dto/response/RefreshTokenDto.java
@@ -1,0 +1,14 @@
+package cmc.mellyserver.mellyapi.auth.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RefreshTokenDto {
+
+    private String token;
+
+    private Long expiredAt;
+
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/dto/response/TokenResponseDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/application/dto/response/TokenResponseDto.java
@@ -1,0 +1,17 @@
+package cmc.mellyserver.mellyapi.auth.application.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TokenResponseDto {
+
+    private String accessToken;
+
+    private String refreshToken;
+
+    public static TokenResponseDto of(String accessToken, String refreshToken) {
+        return new TokenResponseDto(accessToken, refreshToken);
+    }
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/AuthController.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/AuthController.java
@@ -6,10 +6,8 @@ import cmc.mellyserver.mellyapi.auth.application.dto.request.ChangePasswordReque
 import cmc.mellyserver.mellyapi.auth.application.dto.response.TokenResponseDto;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.common.CurrentUser;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.common.LoginUser;
-import cmc.mellyserver.mellyapi.auth.presentation.dto.request.AuthLoginRequest;
-import cmc.mellyserver.mellyapi.auth.presentation.dto.request.CommonSignupRequest;
-import cmc.mellyserver.mellyapi.auth.presentation.dto.request.OAuthLoginRequest;
-import cmc.mellyserver.mellyapi.auth.presentation.dto.request.ReIssueAccessTokenRequest;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.request.*;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.response.OAuthResponseDto;
 import cmc.mellyserver.mellyapi.common.response.ApiResponse;
 import cmc.mellyserver.mellyapi.common.util.HeaderUtil;
 import cmc.mellyserver.mellyinfra.email.EmailCertificationRequest;
@@ -43,9 +41,17 @@ public class AuthController {
     @PostMapping("/social")
     public ResponseEntity<ApiResponse> socialLogin(@Valid @RequestBody OAuthLoginRequest oAuthLoginRequest) {
 
-        String authToken = oAuthService.login(oAuthLoginRequest.toDto());
-        return OK(authToken);
+        OAuthResponseDto oAuthResponseDto = oAuthService.login(oAuthLoginRequest.toDto());
+        return OK(oAuthResponseDto);
     }
+
+    @PostMapping("/social-signup")
+    public ResponseEntity<ApiResponse> socialSignup(@Valid @RequestBody OAuthSignupRequest oAuthSignupRequest) {
+
+        TokenResponseDto tokenResponseDto = oAuthService.signup(oAuthSignupRequest.toDto());
+        return OK(tokenResponseDto);
+    }
+
 
     // 이메일 회원 가입
     @PostMapping("/signup")
@@ -126,10 +132,10 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/access-token/reissue")
+    @PostMapping("/token/reissue")
     public ResponseEntity<ApiResponse> generateAccessToken(@RequestBody ReIssueAccessTokenRequest reIssueAccessTokenRequest) {
 
-        TokenResponseDto tokenResponseDto = authService.reIssueAccessToken(reIssueAccessTokenRequest.getRefreshToken());
+        TokenResponseDto tokenResponseDto = authService.reIssueAccessTokenAndRefreshToken(reIssueAccessTokenRequest.getRefreshToken());
         return OK(tokenResponseDto);
     }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/AuthController.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/AuthController.java
@@ -3,11 +3,13 @@ package cmc.mellyserver.mellyapi.auth.presentation;
 import cmc.mellyserver.mellyapi.auth.application.AuthService;
 import cmc.mellyserver.mellyapi.auth.application.OAuthService;
 import cmc.mellyserver.mellyapi.auth.application.dto.request.ChangePasswordRequest;
+import cmc.mellyserver.mellyapi.auth.application.dto.response.TokenResponseDto;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.common.CurrentUser;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.common.LoginUser;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.request.AuthLoginRequest;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.request.CommonSignupRequest;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.request.OAuthLoginRequest;
+import cmc.mellyserver.mellyapi.auth.presentation.dto.request.ReIssueAccessTokenRequest;
 import cmc.mellyserver.mellyapi.common.response.ApiResponse;
 import cmc.mellyserver.mellyapi.common.util.HeaderUtil;
 import cmc.mellyserver.mellyinfra.email.EmailCertificationRequest;
@@ -49,16 +51,16 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<ApiResponse> signup(@Valid CommonSignupRequest commonSignupRequest) {
 
-        String authToken = authService.signup(commonSignupRequest.toDto());
-        return OK(authToken);
+        TokenResponseDto signupToken = authService.emailSignup(commonSignupRequest.toDto());
+        return OK(signupToken);
     }
 
     // 이메일 로그인
     @PostMapping("/login")
     public ResponseEntity<ApiResponse> login(@Valid @RequestBody AuthLoginRequest authLoginRequest) {
 
-        String authToken = authService.login(authLoginRequest.toDto());
-        return OK(authToken);
+        TokenResponseDto loginToken = authService.login(authLoginRequest.toDto());
+        return OK(loginToken);
     }
 
     // 이메일 유효성을 파악하기 위해 인증번호 전송
@@ -124,4 +126,10 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    @PostMapping("/access-token/reissue")
+    public ResponseEntity<ApiResponse> generateAccessToken(@RequestBody ReIssueAccessTokenRequest reIssueAccessTokenRequest) {
+
+        TokenResponseDto tokenResponseDto = authService.reIssueAccessToken(reIssueAccessTokenRequest.getRefreshToken());
+        return OK(tokenResponseDto);
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/OAuthSignupRequest.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/OAuthSignupRequest.java
@@ -1,0 +1,37 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.request;
+
+import cmc.mellyserver.mellycommon.enums.AgeGroup;
+import cmc.mellyserver.mellycommon.enums.Gender;
+import cmc.mellyserver.mellycommon.enums.Provider;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OAuthSignupRequest {
+
+    // Oauth를 통해 넘겨받은 정보
+    private String email;
+
+    private String socialId;
+
+    private Provider provider;
+
+    // 입력 정보
+    @Length(min = 2, max = 15, message = "닉네임은 2자 이상 15자 이하로 작성해주세요.")
+    private String nickname; // 닉네임
+
+
+    private Gender gender; // 성별
+
+
+    private AgeGroup ageGroup; // 연령대
+
+    private String fcmToken;
+
+    public OAuthSignupRequestDto toDto() {
+        return new OAuthSignupRequestDto(email, socialId, provider, nickname, gender, ageGroup, fcmToken);
+    }
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/OAuthSignupRequestDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/OAuthSignupRequestDto.java
@@ -1,0 +1,28 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.request;
+
+import cmc.mellyserver.mellycommon.enums.AgeGroup;
+import cmc.mellyserver.mellycommon.enums.Gender;
+import cmc.mellyserver.mellycommon.enums.Provider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OAuthSignupRequestDto {
+
+    private String email;
+
+    private String socialId;
+
+    private Provider provider;
+
+    private String nickname;
+
+
+    private Gender gender;
+
+
+    private AgeGroup ageGroup;
+
+    private String fcmToken;
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/ReIssueAccessTokenRequest.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/request/ReIssueAccessTokenRequest.java
@@ -1,0 +1,11 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.request;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class ReIssueAccessTokenRequest {
+
+    private String refreshToken;
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/OAuthResponseDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/OAuthResponseDto.java
@@ -1,0 +1,14 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.response;
+
+import cmc.mellyserver.mellyapi.auth.application.dto.response.TokenResponseDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OAuthResponseDto<T> {
+
+    public TokenResponseDto tokenInfo;
+
+    public T data;
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/OAuthSignupResponseDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/OAuthSignupResponseDto.java
@@ -1,0 +1,16 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.response;
+
+import cmc.mellyserver.mellycommon.enums.Provider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class OAuthSignupResponseDto {
+
+    private String email;
+
+    private String socialId;
+
+    private Provider provider;
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/UserExistResponseDto.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/presentation/dto/response/UserExistResponseDto.java
@@ -1,0 +1,14 @@
+package cmc.mellyserver.mellyapi.auth.presentation.dto.response;
+
+import cmc.mellyserver.mellycommon.enums.Provider;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class UserExistResponseDto {
+
+    private Provider provider;
+
+    private String email;
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/repository/RefreshToken.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/repository/RefreshToken.java
@@ -1,0 +1,22 @@
+package cmc.mellyserver.mellyapi.auth.repository;
+
+public class RefreshToken {
+
+    private Long userId; // 분명이 구성이 맞다.
+
+    private String refreshToken; // 이 구성이 맞는 것 같아
+
+
+    public RefreshToken(final String refreshToken, final Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/repository/RefreshTokenRepository.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,35 @@
+package cmc.mellyserver.mellyapi.auth.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Repository
+public class RefreshTokenRepository {
+
+    private RedisTemplate redisTemplate;
+
+    public RefreshTokenRepository(final RedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(final RefreshToken refreshToken, final Long refreshTokenExpire) {
+        redisTemplate.opsForValue().set(refreshToken.getRefreshToken(), refreshToken.getUserId());
+        redisTemplate.expire(refreshToken.getRefreshToken(), refreshTokenExpire, TimeUnit.MILLISECONDS);
+    }
+
+    public Optional<RefreshToken> findById(final String refreshToken) {
+        ValueOperations<String, Long> valueOperations = redisTemplate.opsForValue();
+        Long userId = valueOperations.get(refreshToken);
+
+        if (Objects.isNull(userId)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new RefreshToken(refreshToken, userId));
+    }
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/comment/presentation/CommentController.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/comment/presentation/CommentController.java
@@ -6,7 +6,7 @@ import cmc.mellyserver.mellyapi.comment.presentation.dto.CommentAssembler;
 import cmc.mellyserver.mellyapi.comment.presentation.dto.request.CommentRequest;
 import cmc.mellyserver.mellyapi.comment.presentation.dto.request.CommentUpdateRequest;
 import cmc.mellyserver.mellyapi.comment.presentation.dto.request.LikeRequest;
-import cmc.mellyserver.mellyapi.common.constants.MessageConstant;
+import cmc.mellyserver.mellyapi.common.constants.MessageConstants;
 import cmc.mellyserver.mellyapi.common.response.ApiResponse;
 import cmc.mellyserver.mellycore.comment.application.CommentLikeService;
 import cmc.mellyserver.mellycore.comment.application.CommentService;
@@ -34,14 +34,14 @@ public class CommentController {
     public ResponseEntity<ApiResponse> removeCommentLike(@AuthenticationPrincipal User user, @PathVariable Long commentId) {
 
         commentLikeService.deleteCommentLike(commentId, Long.parseLong(user.getUsername()));
-        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS));
+        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstants.MESSAGE_SUCCESS));
     }
 
     @PostMapping("/like")
     public ResponseEntity<ApiResponse> saveCommentLike(@AuthenticationPrincipal User user, @RequestBody LikeRequest likeRequest) {
 
         commentLikeService.saveCommentLike(Long.parseLong(user.getUsername()), likeRequest.getCommentId());
-        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS));
+        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstants.MESSAGE_SUCCESS));
     }
 
     @PostMapping
@@ -62,13 +62,13 @@ public class CommentController {
     public ResponseEntity<ApiResponse> removeComment(@PathVariable Long commentId) {
 
         commentService.deleteComment(commentId);
-        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS));
+        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstants.MESSAGE_SUCCESS));
     }
 
     @PutMapping("/{commentId}")
     public ResponseEntity<ApiResponse> updateComment(@PathVariable Long commentId, @RequestBody CommentUpdateRequest commentUpdateRequest) {
 
         commentService.updateComment(commentId, commentUpdateRequest.getContent());
-        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS));
+        return ResponseEntity.ok(new ApiResponse(HttpStatus.OK.value(), MessageConstants.MESSAGE_SUCCESS));
     }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/MessageConstants.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/MessageConstants.java
@@ -1,6 +1,6 @@
 package cmc.mellyserver.mellyapi.common.constants;
 
-public class MessageConstant {
+public class MessageConstants {
 
     public static final String MESSAGE_SUCCESS = "성공";
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/RedisConstants.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/RedisConstants.java
@@ -1,0 +1,8 @@
+package cmc.mellyserver.mellyapi.common.constants;
+
+public class RedisConstants {
+
+    public static final String REFRESH_TOKEN_PREFIX = "rft:user-id:";
+
+    public static final String ACCESS_TOKEN_BLACKLIST = "blackList";
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/ResponseConstants.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/constants/ResponseConstants.java
@@ -7,22 +7,22 @@ import org.springframework.http.ResponseEntity;
 public class ResponseConstants {
 
     public static final ResponseEntity<ApiResponse> OK = ResponseEntity.ok(
-        new ApiResponse(HttpStatus.OK.value(), MessageConstant.MESSAGE_SUCCESS));
+            new ApiResponse(HttpStatus.OK.value(), MessageConstants.MESSAGE_SUCCESS));
 
     public static final ResponseEntity<Void> CREATED = ResponseEntity.status(HttpStatus.CREATED)
-        .build();
+            .build();
     public static final ResponseEntity<HttpStatus> RESPONSE_CONFLICT = ResponseEntity.status(
-        HttpStatus.CONFLICT).build();
+            HttpStatus.CONFLICT).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_BAD_REQUEST = ResponseEntity.status(
-        HttpStatus.BAD_REQUEST).build();
+            HttpStatus.BAD_REQUEST).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_NOT_FOUND = ResponseEntity.status(
-        HttpStatus.NOT_FOUND).build();
+            HttpStatus.NOT_FOUND).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_UNAUTHORIZED = ResponseEntity.status(
-        HttpStatus.UNAUTHORIZED).build();
+            HttpStatus.UNAUTHORIZED).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_FORBIDDEN = ResponseEntity.status(
-        HttpStatus.FORBIDDEN).build();
+            HttpStatus.FORBIDDEN).build();
     public static final ResponseEntity<HttpStatus> RESPONSE_PAYLOAD_TOO_LARGE = ResponseEntity.status(
-        HttpStatus.PAYLOAD_TOO_LARGE).build();
+            HttpStatus.PAYLOAD_TOO_LARGE).build();
 
     public static final ResponseEntity<Void> NO_CONTENT = ResponseEntity.noContent().build();
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/LogoutOrWithdrawExpcetion.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/exception/LogoutOrWithdrawExpcetion.java
@@ -1,0 +1,8 @@
+package cmc.mellyserver.mellyapi.common.exception;
+
+public class LogoutOrWithdrawExpcetion extends RuntimeException {
+
+    public LogoutOrWithdrawExpcetion(String message) {
+        super(message);
+    }
+}

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/JwtExceptionFilter.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/JwtExceptionFilter.java
@@ -1,28 +1,25 @@
 package cmc.mellyserver.mellyapi.common.filter;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import cmc.mellyserver.mellyapi.common.response.ErrorResponse;
+import cmc.mellyserver.mellycommon.codes.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import io.jsonwebtoken.JwtException;
+import java.io.IOException;
 
 @Component
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
 	@Override
 	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
-		ServletException,
-		IOException {
+			ServletException,
+			IOException {
 		try {
 			chain.doFilter(request, response);
 		} catch (JwtException ex) {
@@ -31,17 +28,16 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
 	}
 
 	public void setErrorResponse(HttpServletRequest request, HttpServletResponse response, Throwable ex) throws
-		IOException {
+			IOException {
 
-		final Map<String, Object> body = new HashMap<>();
+
 		response.setContentType("application/json; charset=UTF-8");
 		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-		body.put("code", "1007");
-		body.put("message", ex.getMessage());
+		ErrorResponse error = ErrorResponse.of(ErrorCode.EXPIRED_TOKEN.getCode(), ex.getMessage());
 
 		final ObjectMapper mapper = new ObjectMapper();
-		mapper.writeValue(response.getOutputStream(), body);
+		mapper.writeValue(response.getOutputStream(), error);
 
 	}
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/JwtExceptionFilter.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/JwtExceptionFilter.java
@@ -1,5 +1,6 @@
 package cmc.mellyserver.mellyapi.common.filter;
 
+import cmc.mellyserver.mellyapi.common.exception.LogoutOrWithdrawExpcetion;
 import cmc.mellyserver.mellyapi.common.response.ErrorResponse;
 import cmc.mellyserver.mellycommon.codes.ErrorCode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -16,28 +17,40 @@ import java.io.IOException;
 @Component
 public class JwtExceptionFilter extends OncePerRequestFilter {
 
-	@Override
-	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
-			ServletException,
-			IOException {
-		try {
-			chain.doFilter(request, response);
-		} catch (JwtException ex) {
-			setErrorResponse(request, response, ex);
-		}
-	}
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws
+            ServletException,
+            IOException {
+        try {
+            chain.doFilter(request, response);
+        } catch (JwtException ex) {
+            setExpiredErrorResponse(request, response, ex);
+        } catch (LogoutOrWithdrawExpcetion ex) {
+            setLogoutOrWithdrawErrorResponse(request, response, ex);
+        }
+    }
 
-	public void setErrorResponse(HttpServletRequest request, HttpServletResponse response, Throwable ex) throws
-			IOException {
+    public void setExpiredErrorResponse(HttpServletRequest request, HttpServletResponse response, Throwable ex) throws
+            IOException {
 
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-		response.setContentType("application/json; charset=UTF-8");
-		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        ErrorResponse error = ErrorResponse.of(ErrorCode.EXPIRED_TOKEN.getCode(), ex.getMessage());
 
-		ErrorResponse error = ErrorResponse.of(ErrorCode.EXPIRED_TOKEN.getCode(), ex.getMessage());
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), error);
+    }
 
-		final ObjectMapper mapper = new ObjectMapper();
-		mapper.writeValue(response.getOutputStream(), error);
+    public void setLogoutOrWithdrawErrorResponse(HttpServletRequest request, HttpServletResponse response, Throwable ex) throws
+            IOException {
 
-	}
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ErrorResponse error = ErrorResponse.of(ErrorCode.LOGOUT_WITHDRAW_USER.getCode(), ex.getMessage());
+
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), error);
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/TokenAuthenticationFilter.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/filter/TokenAuthenticationFilter.java
@@ -22,8 +22,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider tokenProvider;
 
     @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-                                    FilterChain filterChain) throws ServletException, IOException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
         String jwt = HeaderUtil.getAccessToken(request);
 
@@ -36,10 +35,6 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             logger.debug("Security Context에  인증 정보를 저장했습니다");
-
-        } else {
-
-            logger.debug("유효한 JWT 토큰이 없습니다");
 
         }
 

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/handler/LoginUserIdArgumentResolver.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/handler/LoginUserIdArgumentResolver.java
@@ -4,6 +4,7 @@ import cmc.mellyserver.mellyapi.auth.presentation.dto.common.CurrentUser;
 import cmc.mellyserver.mellyapi.auth.presentation.dto.common.LoginUser;
 import cmc.mellyserver.mellyapi.common.token.JwtTokenProvider;
 import cmc.mellyserver.mellyapi.common.util.HeaderUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -14,13 +15,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 import javax.servlet.http.HttpServletRequest;
 
 @Component
-public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+@RequiredArgsConstructor
+public class LoginUserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider tokenProvider;
 
-    public LoginUserArgumentResolver(final JwtTokenProvider jwtTokenProvider) {
-        this.jwtTokenProvider = jwtTokenProvider;
-    }
 
     @Override
     public boolean supportsParameter(final MethodParameter parameter) {
@@ -32,7 +31,7 @@ public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver 
                                   final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
         String accessToken = HeaderUtil.getAccessToken(request);
-        Long id = Long.valueOf(jwtTokenProvider.getPayLoad(accessToken));
+        Long id = tokenProvider.extractMemberId(accessToken);
         return new LoginUser(id);
     }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/handler/RestAuthenticationEntryPoint.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/handler/RestAuthenticationEntryPoint.java
@@ -1,41 +1,31 @@
 package cmc.mellyserver.mellyapi.common.handler;
 
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import cmc.mellyserver.mellyapi.common.response.ErrorResponse;
+import cmc.mellyserver.mellycommon.codes.ErrorCode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import lombok.extern.slf4j.Slf4j;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
 
 @Slf4j
 @Component
 public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-	@Override
-	public void commence(HttpServletRequest request, HttpServletResponse response,
-		AuthenticationException authException) throws IOException {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
 
-		final Map<String, Object> body = new HashMap<>();
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
 
-		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-		response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        ErrorResponse error = ErrorResponse.of(ErrorCode.UNAUTHORIZED_USER.getCode(), authException.getMessage());
 
-		body.put("code", "1005");
-		body.put("message", "인증되지 않은 유저입니다.");
-
-		final ObjectMapper mapper = new ObjectMapper();
-
-		mapper.writeValue(response.getOutputStream(), body);
-
-	}
+        final ObjectMapper mapper = new ObjectMapper();
+        mapper.writeValue(response.getOutputStream(), error);
+    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/token/JwtTokenProvider.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/token/JwtTokenProvider.java
@@ -96,6 +96,19 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 
+    public Long getLastExpireTime(String token) {
+
+        Date expirationDate = Jwts
+                .parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody().getExpiration();
+
+        return expirationDate.getTime() - new Date().getTime();
+
+    }
+
     public Long extractMemberId(final String accessToken) {
         try {
             String memberId = Jwts.parserBuilder()

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/token/JwtTokenProvider.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/token/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package cmc.mellyserver.mellyapi.common.token;
 
+import cmc.mellyserver.mellyapi.auth.application.dto.response.RefreshTokenDto;
 import cmc.mellyserver.mellycommon.enums.RoleType;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
@@ -23,54 +24,64 @@ import java.util.stream.Collectors;
 @Component
 public class JwtTokenProvider {
 
-    protected static final String AUTHORITIES_KEY = "auth";
+    protected static final String AUTHORITIES_KEY = "access";
+
     protected final String secret;
-    protected final long tokenValidityInMilliseconds;
 
-    protected Key key;
+    private final long accessExpirationTime;
 
-    public JwtTokenProvider(@Value("${app.auth.tokenSecret}") String secret,
-                            @Value("${app.auth.tokenExpiry}") long tokenValidityInSeconds) {
+    private final long refreshExpirationTime;
+
+    protected Key secretKey;
+
+    public JwtTokenProvider(@Value("${app.auth.token-secret}") String secret,
+                            @Value("${app.auth.access-expiration-time}") long accessExpirationTime,
+                            @Value("${app.auth.refresh-expiration-time}") long refreshExpirationTime
+    ) {
         this.secret = secret;
-        this.tokenValidityInMilliseconds = tokenValidityInSeconds * 1000;
+        this.accessExpirationTime = accessExpirationTime;
+        this.refreshExpirationTime = refreshExpirationTime;
         byte[] keyBytes = Decoders.BASE64.decode(secret);
-        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
     }
 
     // 토큰 생성
-    public String createToken(Long userSeq, RoleType role) {
+    public String createAccessToken(Long userId, RoleType roleType) {
 
-        // 현재시간
-        long now = (new Date()).getTime();
-
-        // 만료되는 날짜
-        Date validity = new Date(now + this.tokenValidityInMilliseconds);
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + accessExpirationTime);
 
         return Jwts.builder()
-                .setSubject(Long.toString(userSeq))
-                .claim(AUTHORITIES_KEY, role.toString())
-                .signWith(key, SignatureAlgorithm.HS512)
-                .setExpiration(validity)
+                .signWith(secretKey)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .setSubject(String.valueOf(userId))
+                .claim(AUTHORITIES_KEY, roleType.getCode())
+                .compact();
+    }
+
+    public RefreshTokenDto createRefreshToken(Long userId, RoleType roleType) {
+
+        Date now = new Date();
+        Date expireDate = new Date(now.getTime() + refreshExpirationTime);
+
+        String token = Jwts.builder()
+                .signWith(secretKey)
+                .setIssuedAt(now)
+                .setExpiration(expireDate)
+                .setSubject(String.valueOf(userId))
+                .claim(AUTHORITIES_KEY, roleType.getCode())
                 .compact();
 
+        return new RefreshTokenDto(token, refreshExpirationTime);
     }
 
-    public Long getPayLoad(String token) {
-        Claims claims = Jwts
-                .parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
-
-        return Long.valueOf(claims.getSubject());
-    }
 
     public Authentication getAuthentication(String token) {
 
         Claims claims = Jwts
                 .parserBuilder()
-                .setSigningKey(key)
+                .setSigningKey(secretKey)
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
@@ -85,14 +96,28 @@ public class JwtTokenProvider {
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 
+    public Long extractMemberId(final String accessToken) {
+        try {
+            String memberId = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody()
+                    .getSubject();
+            return Long.parseLong(memberId);
+        } catch (final JwtException e) {
+            throw new IllegalArgumentException();
+        }
+    }
+
     public boolean validateToken(String token) {
         try {
-            Claims claims = Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+            Claims claims = Jwts.parserBuilder().setSigningKey(secretKey).build().parseClaimsJws(token).getBody();
             return true;
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.info("잘못된 JWT 서명입니다.");
         } catch (ExpiredJwtException e) {
-            log.info("만료된 JWT 토큰입니다.");
+            throw new JwtException("엑세스 토큰이 만료되었습니다.");
         } catch (UnsupportedJwtException e) {
             log.info("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/util/HeaderUtil.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/common/util/HeaderUtil.java
@@ -13,13 +13,9 @@ public class HeaderUtil {
 
     public static String getAccessToken(HttpServletRequest request) {
 
-        String headerValue = request.getHeader(HEADER_AUTHORIZATION);
+        String headerValue = request.getHeader(HEADER_AUTHORIZATION); // Bearer token
 
-        if (Objects.isNull(headerValue)) {
-            return null;
-        }
-
-        if (headerValue.startsWith(TOKEN_PREFIX)) {
+        if (!Objects.isNull(headerValue) && headerValue.startsWith(TOKEN_PREFIX)) {
 
             return headerValue.substring(TOKEN_PREFIX.length());
         }
@@ -27,6 +23,4 @@ public class HeaderUtil {
         return null;
     }
 
-    private HeaderUtil() {
-    }
 }

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/SecurityConfig.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
                 .antMatchers("/actuator/**", "/v3/api-docs/**", "/api/memory/**", "/api/place/list", "/api/imageTest",
-                        "/api/pw", "/api/optional", "/auth/social/signup", "/api/auth/social", "/api/auth/signup", "/api/auth/login",
+                        "/api/pw", "/api/optional", "/auth/social/signup", "/api/auth/social", "/api/auth/signup", "/api/auth/login", "/api/auth/access-token/reissue",
                         "/auth/nickname", "/auth/email", "/api/health", "/api/auth/email-certification/sends", "/api/auth/email-certification/resends", "/api/auth/email-certification/confirms", "/").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/SecurityConfig.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import cmc.mellyserver.mellyapi.common.token.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -24,6 +25,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final RedisTemplate redisTemplate;
+
     private final RestAuthenticationEntryPoint authenticationEntryPoint;
     private final TokenAccessDeniedHandler accessDeniedHandler;
     private final JwtExceptionFilter jwtExceptionFilter;
@@ -36,7 +40,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
 
-        TokenAuthenticationFilter authenticationFilter = new TokenAuthenticationFilter(jwtTokenProvider);
+        TokenAuthenticationFilter authenticationFilter = new TokenAuthenticationFilter(jwtTokenProvider, redisTemplate);
 
         http
                 .cors()
@@ -54,8 +58,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .antMatchers(HttpMethod.OPTIONS).permitAll()
                 .antMatchers("/actuator/**", "/v3/api-docs/**", "/api/memory/**", "/api/place/list", "/api/imageTest",
-                        "/api/pw", "/api/optional", "/auth/social/signup", "/api/auth/social", "/api/auth/signup", "/api/auth/login", "/api/auth/access-token/reissue",
-                        "/auth/nickname", "/auth/email", "/api/health", "/api/auth/email-certification/sends", "/api/auth/email-certification/resends", "/api/auth/email-certification/confirms", "/").permitAll()
+                        "/api/pw", "/api/optional", "/auth/social/signup", "/api/auth/social", "/api/auth/signup", "/api/auth/login", "/api/auth/token/reissue",
+                        "/auth/nickname", "/auth/email", "/api/health", "/api/auth/email-certification/sends", "/api/auth/email-certification/resends", "/api/auth/email-certification/confirms", "/api/auth/social-signup", "/").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(authenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/WebConfig.java
+++ b/melly-api/src/main/java/cmc/mellyserver/mellyapi/config/WebConfig.java
@@ -1,6 +1,6 @@
 package cmc.mellyserver.mellyapi.config;
 
-import cmc.mellyserver.mellyapi.common.handler.LoginUserArgumentResolver;
+import cmc.mellyserver.mellyapi.common.handler.LoginUserIdArgumentResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -12,7 +12,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
 
-    private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final LoginUserIdArgumentResolver loginUserArgumentResolver;
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {

--- a/melly-api/src/main/resources/application-prod.yml
+++ b/melly-api/src/main/resources/application-prod.yml
@@ -43,8 +43,9 @@ spring:
 
 app:
   auth:
-    tokenExpiry: ${JWT_EXPIRY}
-    tokenSecret: ${JWT_SECRET}
+    access-expiration-time: ${ACCESS_TOKEN_EXPIRE} # 30분 1800000
+    refresh-expiration-time: ${REFRESH_TOKEN_EXPIRE} # 2주
+    token-secret: ${JWT_SECRET}
 
 cloud:
   aws:
@@ -53,6 +54,7 @@ cloud:
     stack:
       auto: false
     s3:
+      cloud-front-url: ${CLOUD_FRONT_URL}
       bucket: ${S3_BUCKET}
     credentials:
       access-key: ${S3_ACCESS_KEY}

--- a/melly-common/src/main/java/cmc/mellyserver/mellycommon/codes/ErrorCode.java
+++ b/melly-common/src/main/java/cmc/mellyserver/mellycommon/codes/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
     UNAUTHORIZED_USER(HttpStatus.UNAUTHORIZED.value(), "AUTH-006", "인증되지 않은 유저입니다."),
     FORBIDDEN_USER(HttpStatus.FORBIDDEN.value(), "AUTH-007", "접근 권한이 없는 유저입니다."),
 
+    RE_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED.value(), "AUTH-008", "토큰 기한 만료로 재로그인이 필요합니다."),
+
     BEFORE_PASSWORD_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "AUTH-008", "이전 비밀번호가 일치하지 않습니다."),
     // User
     DUPLICATE_EMAIL(HttpStatus.CONFLICT.value(), "USER-001", "중복되는 이메일입니다."),

--- a/melly-common/src/main/java/cmc/mellyserver/mellycommon/codes/ErrorCode.java
+++ b/melly-common/src/main/java/cmc/mellyserver/mellycommon/codes/ErrorCode.java
@@ -28,7 +28,12 @@ public enum ErrorCode {
 
     RE_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED.value(), "AUTH-008", "토큰 기한 만료로 재로그인이 필요합니다."),
 
-    BEFORE_PASSWORD_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "AUTH-008", "이전 비밀번호가 일치하지 않습니다."),
+    BEFORE_PASSWORD_NOT_EXIST(HttpStatus.BAD_REQUEST.value(), "AUTH-009", "이전 비밀번호가 일치하지 않습니다."),
+
+    ABNORMAL_ACCESS(HttpStatus.UNAUTHORIZED.value(), "AUTH-010", "비정상적인 접속이 감지되어 재로그인 필요합니다."),
+
+    LOGOUT_WITHDRAW_USER(HttpStatus.UNAUTHORIZED.value(), "AUTH-011", "이미 로그아웃 했거나 탈퇴한 유저입니다."),
+
     // User
     DUPLICATE_EMAIL(HttpStatus.CONFLICT.value(), "USER-001", "중복되는 이메일입니다."),
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT.value(), "USER-002", "중복되는 닉네임입니다."),

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/common/aws/S3Constants.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/common/aws/S3Constants.java
@@ -2,5 +2,5 @@ package cmc.mellyserver.mellycore.common.aws;
 
 public class S3Constants {
 
-    public static final String IMAGE_UPLOAD_BUCKET_NAME = "mellyimage";
+    public static final String IMAGE_UPLOAD_BUCKET_NAME = "melly";
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/common/aws/StorageService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/common/aws/StorageService.java
@@ -13,5 +13,5 @@ public interface StorageService {
 
     void deleteFile(String fileName) throws IOException;
 
-    Long calculateImageVolume(String bucketName, String username);
+    Long calculateImageVolume(String username);
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/RedisConfig.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/config/redis/RedisConfig.java
@@ -6,7 +6,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -24,13 +23,11 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    public RedisTemplate<?, ?> redisTemplate() {
 
-        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory);
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
-
+        RedisTemplate<byte[], byte[]> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
         return redisTemplate;
+
     }
 }

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/group/exception/GroupNotFoundException.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/group/exception/GroupNotFoundException.java
@@ -1,4 +1,0 @@
-package cmc.mellyserver.mellycore.group.exception;
-
-public class GroupNotFoundException extends RuntimeException {
-}

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryWriteService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryWriteService.java
@@ -7,13 +7,11 @@ import cmc.mellyserver.mellycore.common.aws.StorageService;
 import cmc.mellyserver.mellycore.common.exception.BusinessException;
 import cmc.mellyserver.mellycore.group.domain.UserGroup;
 import cmc.mellyserver.mellycore.group.domain.repository.GroupRepository;
-import cmc.mellyserver.mellycore.group.exception.GroupNotFoundException;
 import cmc.mellyserver.mellycore.memory.application.dto.request.CreateMemoryRequestDto;
 import cmc.mellyserver.mellycore.memory.application.dto.request.UpdateMemoryRequestDto;
 import cmc.mellyserver.mellycore.memory.domain.Memory;
 import cmc.mellyserver.mellycore.memory.domain.MemoryImage;
 import cmc.mellyserver.mellycore.memory.domain.repository.MemoryRepository;
-import cmc.mellyserver.mellycore.memory.exception.MemoryNotFoundException;
 import cmc.mellyserver.mellycore.place.domain.Place;
 import cmc.mellyserver.mellycore.place.domain.Position;
 import cmc.mellyserver.mellycore.place.domain.repository.PlaceRepository;
@@ -66,11 +64,11 @@ public class MemoryWriteService {
     public void updateMemory(UpdateMemoryRequestDto updateMemoryRequestDto) {
 
         Memory memory = memoryRepository.findById(updateMemoryRequestDto.getMemoryId()).orElseThrow(() -> {
-            throw new MemoryNotFoundException();
+            throw new BusinessException(ErrorCode.NO_SUCH_MEMORY);
         });
 
         UserGroup userGroup = groupRepository.findById(updateMemoryRequestDto.getGroupId()).orElseThrow(() -> {
-            throw new GroupNotFoundException();
+            throw new BusinessException(ErrorCode.DUPLICATED_GROUP);
         });
 
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(updateMemoryRequestDto.getId());
@@ -90,7 +88,7 @@ public class MemoryWriteService {
         memory.delete();
     }
 
-    
+
     private void setPlaceId(CreateMemoryRequestDto createMemoryRequestDto, Memory memory, Place place) {
 
         if (!Objects.isNull(place)) {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryWriteService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/application/MemoryWriteService.java
@@ -90,6 +90,7 @@ public class MemoryWriteService {
         memory.delete();
     }
 
+    
     private void setPlaceId(CreateMemoryRequestDto createMemoryRequestDto, Memory memory, Place place) {
 
         if (!Objects.isNull(place)) {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/repository/MemoryQueryRepository.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/memory/domain/repository/MemoryQueryRepository.java
@@ -1,6 +1,7 @@
 package cmc.mellyserver.mellycore.memory.domain.repository;
 
 
+import cmc.mellyserver.mellycommon.enums.DeleteStatus;
 import cmc.mellyserver.mellycommon.enums.GroupType;
 import cmc.mellyserver.mellycommon.enums.OpenType;
 import cmc.mellyserver.mellycore.memory.domain.repository.dto.ImageDto;
@@ -52,6 +53,7 @@ public class MemoryQueryRepository {
                 .innerJoin(memoryImage).on(memoryImage.memory.id.eq(memory.id)).fetchJoin()
                 .innerJoin(place).on(place.id.eq(memory.placeId)).fetchJoin()
                 .where(
+                        isActive(),
                         ltMemoryId(lastId),
                         createdByLoginUser(userId),
                         eqPlace(placeId),
@@ -75,6 +77,7 @@ public class MemoryQueryRepository {
                 .from(memory)
                 .innerJoin(place).on(place.id.eq(memory.placeId))
                 .where(
+                        isActive(),
                         ltMemoryId(lastId),
                         memory.groupId.eq(groupId),
                         checkOpenTypeAllOrGroup()
@@ -103,6 +106,7 @@ public class MemoryQueryRepository {
                 .from(memory)
                 .innerJoin(place).on(place.id.eq(memory.placeId))
                 .where(
+                        isActive(),
                         ltMemoryId(lastId),
                         createdByLoginUser(userId),
                         eqGroup(groupType)
@@ -149,6 +153,7 @@ public class MemoryQueryRepository {
                 .from(memory)
                 .leftJoin(place).on(place.id.eq(memory.placeId))
                 .where(
+                        isActive(),
                         ltMemoryId(lastId),
                         eqPlace(placeId),
                         createdByNotCurrentLoginUser(userId), // 내가 작성자인 메모리
@@ -172,6 +177,7 @@ public class MemoryQueryRepository {
                 .from(memory)
                 .leftJoin(place).on(place.id.eq(memory.placeId))
                 .where(
+                        isActive(),
                         ltMemoryId(lastId),
                         inSameGroup(userId),
                         eqPlace(placeId),
@@ -264,6 +270,10 @@ public class MemoryQueryRepository {
 
     private static BooleanExpression createdByLoginUser(Long id) {
         return memory.userId.eq(id);
+    }
+
+    private static BooleanExpression isActive() {
+        return memory.is_deleted.eq(DeleteStatus.N);
     }
 
     private static BooleanExpression createdByNotCurrentLoginUser(Long id) {

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/notification/exception/MemoryNotFoundException.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/notification/exception/MemoryNotFoundException.java
@@ -1,4 +1,0 @@
-package cmc.mellyserver.mellycore.notification.exception;
-
-public class MemoryNotFoundException extends RuntimeException {
-}

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/application/UserProfileService.java
@@ -20,8 +20,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.Objects;
 
-import static cmc.mellyserver.mellycore.common.aws.S3Constants.IMAGE_UPLOAD_BUCKET_NAME;
-
 @Service
 @RequiredArgsConstructor
 public class UserProfileService {
@@ -41,7 +39,7 @@ public class UserProfileService {
     public Integer checkImageStorageVolumeLoginUserUse(Long userId) {
 
         User user = authenticatedUserChecker.checkAuthenticatedUserExist(userId);
-        return fileUploader.calculateImageVolume(IMAGE_UPLOAD_BUCKET_NAME, user.getEmail()).intValue();
+        return fileUploader.calculateImageVolume(user.getEmail()).intValue();
     }
 
     /**

--- a/melly-core/src/main/java/cmc/mellyserver/mellycore/user/domain/User.java
+++ b/melly-core/src/main/java/cmc/mellyserver/mellycore/user/domain/User.java
@@ -75,7 +75,7 @@ public class User extends JpaBaseEntity {
     private UserStatus userStatus;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "password_expired", nullable = false)
+    @Column(name = "password_expired")
     private PasswordExpired passwordExpired;
 
     @Column(name = "password_init_date")
@@ -130,6 +130,11 @@ public class User extends JpaBaseEntity {
 
     public void changeCommentLikePushStatus(boolean enableCommentLikePush) {
         this.enableCommentLikePush = enableCommentLikePush;
+    }
+
+    public void updateOauthInfo(String nickname, String socialId) {
+        this.nickname = nickname;
+        this.socialId = socialId;
     }
 
     public void changeCommenPushStatus(boolean enableCommentPush) {
@@ -203,11 +208,15 @@ public class User extends JpaBaseEntity {
     }
 
     // 처음 로그인 시에 얻어올 수 있는 정보는 OAuth에서는 없다.
-    public static User createOauthLoginUser(String socialId, Provider provider) {
+    public static User createOauthLoginUser(String socialId, Provider provider, String email, String nickname, AgeGroup ageGroup, Gender gender) {
 
         return User.builder()
                 .socialId(socialId)
                 .provider(provider)
+                .email(email)
+                .nickname(nickname)
+                .ageGroup(ageGroup)
+                .gender(gender)
                 .password(NO_PASSWORD)
                 .roleType(RoleType.USER)
                 .build();

--- a/melly-infra/build.gradle
+++ b/melly-infra/build.gradle
@@ -8,4 +8,5 @@ dependencies {
     implementation 'com.google.firebase:firebase-admin:7.1.0'
     implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/S3StorageService.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/aws/S3StorageService.java
@@ -24,6 +24,8 @@ public class S3StorageService implements StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    @Value("${cloud.aws.s3.cloud-front-url}")
+    private String CLOUD_FRONT_URL;
     private final AmazonS3Client amazonS3Client;
 
 
@@ -89,17 +91,18 @@ public class S3StorageService implements StorageService {
     }
 
     @Override
-    public Long calculateImageVolume(String bucketName, String username) {
+    public Long calculateImageVolume(String username) {
 
-        ObjectListing mellyimage = amazonS3Client.listObjects(bucketName, username);
+        ObjectListing mellyimage = amazonS3Client.listObjects(bucket, username);
         List<S3ObjectSummary> objectSummaries = mellyimage.getObjectSummaries();
 
         return objectSummaries.stream().mapToLong(S3ObjectSummary::getSize).sum();
+
     }
 
     private String createFileName(Long userId, String fileName) {
 
-        return userId + "/" + UUID.randomUUID().toString().concat(getFileExtension(fileName));
+        return "dev/" + userId + "/" + UUID.randomUUID().toString().concat(getFileExtension(fileName));
     }
 
     private String getFileExtension(String fileName) {
@@ -117,7 +120,7 @@ public class S3StorageService implements StorageService {
     }
 
     private String getFileUrl(String filename) {
-        return amazonS3Client.getUrl(bucket, filename).toString();
+        return CLOUD_FRONT_URL + "/" + filename;
     }
 
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/AppleClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/AppleClient.java
@@ -77,7 +77,7 @@ public class AppleClient implements LoginClient {
 
             Claims body = Jwts.parser().setSigningKey(publicKey).parseClaimsJws(accessToken).getBody();
 
-            return User.createOauthLoginUser(body.getSubject(), APPLE);
+            return User.createOauthLoginUser(body.getSubject(), APPLE, null, null, null, null);
 
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/GoogleClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/GoogleClient.java
@@ -38,6 +38,6 @@ public class GoogleClient implements LoginClient {
                 .bodyToMono(GoogleUserData.class)
                 .block();
 
-        return User.createOauthLoginUser(googleUserResponse.getSub(), GOOGLE);
+        return User.createOauthLoginUser(googleUserResponse.getSub(), GOOGLE, null, null, null, null);
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/KakaoClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/KakaoClient.java
@@ -35,7 +35,7 @@ public class KakaoClient implements LoginClient {
                 .onStatus(HttpStatus::is5xxServerError, clientResponse -> Mono.error(new IllegalArgumentException()))
                 .bodyToMono(KakaoUserData.class)
                 .block();
-
-        return User.createOauthLoginUser(String.valueOf(kakaoUserResponse.getId()), KAKAO);
+        System.out.println(kakaoUserResponse.getId());
+        return User.createOauthLoginUser(String.valueOf(kakaoUserResponse.getId()), KAKAO, null, null, null, null);
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/NaverClient.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/client/NaverClient.java
@@ -37,6 +37,6 @@ public class NaverClient implements LoginClient {
                 .bodyToMono(NaverUserData.class)
                 .block();
 
-        return User.createOauthLoginUser(naverUserResponse.getResponse().getId(), NAVER);
+        return User.createOauthLoginUser(naverUserResponse.getResponse().getId(), NAVER, null, null, null, null);
     }
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/KakaoUserData.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/client/dto/KakaoUserData.java
@@ -14,6 +14,8 @@ public class KakaoUserData {
 
     private Long id;
 
+    private Object kakao_account;
+
     private LocalDateTime connected_at;
 
 }

--- a/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/message/FCMService.java
+++ b/melly-infra/src/main/java/cmc/mellyserver/mellyinfra/message/FCMService.java
@@ -58,8 +58,8 @@ public class FCMService implements MessageService {
         FirebaseMessaging.getInstance().sendAsync(message);
     }
 
-    public void saveToken(String email, String fcmToken) {
-        fcmTokenDao.saveToken(PREFIX_FCMTOKEN + email, fcmToken);
+    public void saveToken(Long userId, String fcmToken) {
+        fcmTokenDao.saveToken(PREFIX_FCMTOKEN + userId, fcmToken);
     }
 
     public void deleteToken(String email) {


### PR DESCRIPTION
## 구현 사항
기존에 유효기간이 긴 리프레시 토큰을 통해 access token을 연장하는 방식을 사용했다. 이 방식은 임의의 공격자가 access token과 refresh 토큰을 모두 탈취 시, refresh token이 살아있는 동안 access token을 지속적으로 사용 가능하다는 단점이 있다. 이를 방지하기 위해 access token 재발행 시, refresh token도 함께 재발행 해서 redis에 저장하는 Refresh Token Rotation(RTR) 방식을 새롭게 적용했다.